### PR TITLE
Add Glama listing metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Masonleenf", "jeongmk522-netizen"]
+}


### PR DESCRIPTION
## Summary
- Adds glama.json so Glama can associate and crawl the Hephaestus MCP/runtime repository.
- Lists the current public maintainer handles for the Agentlas/Hephaestus submission flow.

## Context
- punkpeye/awesome-mcp-servers now requires a Glama listing and score badge before merging MCP server entries.
- This metadata file is the first step toward getting Hephaestus indexed; Docker/release validation for a Glama score badge may still require a follow-up runtime packaging change.