### PR TITLE
Anonymize upstream references and generalize framework names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -435,12 +435,12 @@
   dependency-free built-in cartridges, SSRF-safe readers, receipt ledgers,
   search/read/gather/plan/status/proofs/verify flows, and credential guidance
   that exposes env names and setup commands without printing secret values.
-- **Detachable public-page reader inspired by insane-search.** The adaptive
-  `read.insane_fetch` cartridge is mounted only through `public-web`, `social`,
-  `browser`, `full`, or explicit allow-lists. It records bounded route evidence
-  for direct reads, Reddit RSS, Jina Reader fallback, metadata/feed parsing, and
-  login/paywall hard stops, while keeping `insane-search` as a reader
-  cartridge reference rather than the whole research engine.
+- **Detachable public-page reader inspired by an external resilient-reader
+  design.** The adaptive `read.insane_fetch` cartridge is mounted only through
+  `public-web`, `social`, `browser`, `full`, or explicit allow-lists. It records
+  bounded route evidence for direct reads, Reddit RSS, Jina Reader fallback,
+  metadata/feed parsing, and login/paywall hard stops, while staying a
+  detachable reader cartridge rather than the whole research engine.
 - **Stormbreaker research evidence integration.** Stormbreaker packets can now
   attach research receipts, preflight files, readiness snapshots, capability
   summaries, recommendation metadata, and compact evidence-quality/coverage

--- a/agentlas_cloud/research/adapters/insane_fetch.py
+++ b/agentlas_cloud/research/adapters/insane_fetch.py
@@ -1,8 +1,9 @@
-"""Adaptive public fetch-chain inspired by insane-search.
+"""Adaptive public fetch-chain inspired by external resilient public-page
+reader designs.
 
-This is not the upstream Claude Code plugin. It is Agentlas' own lightweight
-cartridge that tries documented/public routes in a bounded order when the user
-explicitly mounts `read.insane_fetch`.
+This is not the upstream reference implementation it was inspired by. It is
+Agentlas' own lightweight cartridge that tries documented/public routes in a
+bounded order when the user explicitly mounts `read.insane_fetch`.
 """
 
 from __future__ import annotations

--- a/agentlas_cloud/research/social_fallbacks.py
+++ b/agentlas_cloud/research/social_fallbacks.py
@@ -41,8 +41,8 @@ def run_research_social_fallbacks(
             "stormbreaker_fit": "mount_public_web_by_default; social_loadout_only_when_official_api_is_explicitly_allowed",
         },
         "upstream_reference": {
-            "name": "fivetaku/insane-search",
-            "url": "https://github.com/fivetaku/insane-search",
+            "name": "external reference design (not disclosed)",
+            "url": "",
             "role": "reference implementation for resilient public-page reading, not a credentialed social API replacement",
         },
         "no_token_coverage": {

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/insane_fetch.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/insane_fetch.py
@@ -1,8 +1,9 @@
-"""Adaptive public fetch-chain inspired by insane-search.
+"""Adaptive public fetch-chain inspired by external resilient public-page
+reader designs.
 
-This is not the upstream Claude Code plugin. It is Agentlas' own lightweight
-cartridge that tries documented/public routes in a bounded order when the user
-explicitly mounts `read.insane_fetch`.
+This is not the upstream reference implementation it was inspired by. It is
+Agentlas' own lightweight cartridge that tries documented/public routes in a
+bounded order when the user explicitly mounts `read.insane_fetch`.
 """
 
 from __future__ import annotations

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/social_fallbacks.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/social_fallbacks.py
@@ -41,8 +41,8 @@ def run_research_social_fallbacks(
             "stormbreaker_fit": "mount_public_web_by_default; social_loadout_only_when_official_api_is_explicitly_allowed",
         },
         "upstream_reference": {
-            "name": "fivetaku/insane-search",
-            "url": "https://github.com/fivetaku/insane-search",
+            "name": "external reference design (not disclosed)",
+            "url": "",
             "role": "reference implementation for resilient public-page reading, not a credentialed social API replacement",
         },
         "no_token_coverage": {

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/insane_fetch.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/insane_fetch.py
@@ -1,8 +1,9 @@
-"""Adaptive public fetch-chain inspired by insane-search.
+"""Adaptive public fetch-chain inspired by external resilient public-page
+reader designs.
 
-This is not the upstream Claude Code plugin. It is Agentlas' own lightweight
-cartridge that tries documented/public routes in a bounded order when the user
-explicitly mounts `read.insane_fetch`.
+This is not the upstream reference implementation it was inspired by. It is
+Agentlas' own lightweight cartridge that tries documented/public routes in a
+bounded order when the user explicitly mounts `read.insane_fetch`.
 """
 
 from __future__ import annotations

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/social_fallbacks.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/social_fallbacks.py
@@ -41,8 +41,8 @@ def run_research_social_fallbacks(
             "stormbreaker_fit": "mount_public_web_by_default; social_loadout_only_when_official_api_is_explicitly_allowed",
         },
         "upstream_reference": {
-            "name": "fivetaku/insane-search",
-            "url": "https://github.com/fivetaku/insane-search",
+            "name": "external reference design (not disclosed)",
+            "url": "",
             "role": "reference implementation for resilient public-page reading, not a credentialed social API replacement",
         },
         "no_token_coverage": {

--- a/docs/agent-ontology-a2a-plan.md
+++ b/docs/agent-ontology-a2a-plan.md
@@ -132,12 +132,12 @@ Capability           # 통제 어휘(taxonomy) 노드
 
 agentlas_cloud/agent_graph/
   loader.py           # JSONL → 인메모리 그래프
-  validator.py        # grammar.json으로 노드/엣지/공리 검증 (OpenCrab validator 패턴 차용)
+  validator.py        # grammar.json으로 노드/엣지/공리 검증 (외부 문서 온톨로지 검증기 설계 차용)
   query.py            # 그래프 질의: who_produces(X), reachable, is_blocked, plan_path
   migrate.py          # 기존 4개 JSON → AO 생성 (card_migrate.py 패턴)
 ```
 
-> 차용 1줄: OpenCrab에서 *유일하게* 가져올 것 = **"타입 문법 + grammar-validated 엣지 + 증거기반 승격"** 기계장치. 단 대상이 문서→에이전트.
+> 차용 1줄: 외부 문서 온톨로지 도구에서 *유일하게* 가져올 것 = **"타입 문법 + grammar-validated 엣지 + 증거기반 승격"** 기계장치. 단 대상이 문서→에이전트.
 
 **저장 백엔드 결정 (확정): JSONL(진실원) + 인메모리 그래프(런타임) + `registry.sqlite` 재사용(임베딩 인덱스).** 근거:
 - 에이전트는 수십~저백 개 → 인메모리 그래프 질의 sub-ms. Neo4j/무거운 DB 불필요.
@@ -197,7 +197,7 @@ agentlas_cloud/agent_graph/
 | **2. Router** | AO 질의를 router에 통합(공리차단·능력필터·경로탐색), 임베딩 pre-filter | 온톨로지 검증 라우팅 + 진짜 pipeline | 라우팅이 똑똑해짐 |
 | **3. Governance** | Policy Office 규칙을 공리로 이전, 결정시점 검증·영수증 | 기계강제 통신규칙 | 위반 자동차단 |
 | **4. A2A** | Agent Card 수입/수출·정렬계층 | A2A 발화/수용 | 외부 에이전트 합류 |
-| **5. (선택) 진화** | 에이전트가 온톨로지 수정 제안 → curator/policy 리뷰 → 승격(candidate→validated→promoted, receipt) | 자가진화 AO | OpenCrab 승격패턴 적용 |
+| **5. (선택) 진화** | 에이전트가 온톨로지 수정 제안 → curator/policy 리뷰 → 승격(candidate→validated→promoted, receipt) | 자가진화 AO | 외부 문서 온톨로지 승격패턴 적용 |
 
 ## 8. 성공 지표
 

--- a/docs/agentlas-research-engine.md
+++ b/docs/agentlas-research-engine.md
@@ -73,8 +73,9 @@ not Reddit OAuth or Threads Graph API. It does not mount `read.insane_fetch`,
 Jina, official social APIs, or browser modules unless the caller selects a
 heavier loadout or explicitly allows that module.
 
-`insane-search` is best treated as a reference for a detachable public-page
-reader, not as the whole Agentlas research brain. Agentlas keeps the planner,
+The upstream design this cartridge was inspired by is best treated as a
+reference for a detachable public-page reader, not as the whole Agentlas
+research brain. Agentlas keeps the planner,
 module policy, ranking, receipts, preflight, and Stormbreaker packet contract
 inside the Research Engine, then mounts `read.insane_fetch` only when
 `public-web`, `social`, `browser`, `full`, or an explicit allow-list asks for
@@ -509,7 +510,7 @@ bounded search follow-up through the built-in registry:
 | `search.github_repos` | `light` | available | No-key GitHub REST repository search for public repo discovery. It is mounted by `public-web`/`full`, but auto fan-out uses it only for GitHub hints or explicit `--provider github`. |
 | `search.jina` | `external_light` | available if configured | Jina web search cartridge for explicit `research search` calls; requires `AGENTLAS_JINA_API_KEY` or `JINA_API_KEY`. |
 | `read.http` | `light` | available | Safe static HTTP/HTML reader. |
-| `read.insane_fetch` | `adaptive_medium` | available if allowed | Bounded public-route fetch-chain inspired by insane-search: direct read, Reddit `.rss`, Jina Reader fallback, metadata/feed parsing, route trace evidence, and hard stop on login/paywall. This stays a detachable public reader, not the core research engine. |
+| `read.insane_fetch` | `adaptive_medium` | available if allowed | Bounded public-route fetch-chain inspired by an external resilient-reader design: direct read, Reddit `.rss`, Jina Reader fallback, metadata/feed parsing, route trace evidence, and hard stop on login/paywall. This stays a detachable public reader, not the core research engine. |
 | `read.jina` | `external_light` | available if allowed | Jina Reader URL-to-markdown cartridge; plain URL reads are not sent to Jina unless this module is explicitly allowed. |
 | `browser.playwright_mcp` | `browser_heavy` | available if configured | Optional Playwright MCP snapshot bridge. The engine calls a configured local snapshot command and records an accessibility-tree snapshot without importing Playwright or MCP packages. |
 | `browser.browser_use` | `browser_heavy` | available if configured | Optional Browser Use snapshot bridge for local or hosted Browser Use harnesses. The engine calls a configured local command and records bounded text output. |

--- a/docs/builder-quality-research-basis.md
+++ b/docs/builder-quality-research-basis.md
@@ -11,14 +11,14 @@ source research into agent behavior.
 | --- | --- | --- |
 | ReAct, arXiv 2210.03629, https://arxiv.org/abs/2210.03629 | academic | Agent prompts should make reasoning, tool use, observation, and next action explicit enough to debug. |
 | Reflexion, arXiv 2303.11366, https://arxiv.org/abs/2303.11366 | academic | Agents need evaluation feedback, failure notes, and memory candidates instead of static one-shot prompts. |
-| DSPy, https://github.com/stanfordnlp/dspy | GitHub | Treat prompts as structured modules with signatures, examples, and evaluation pressure, not as loose prose. |
-| LangGraph, https://github.com/langchain-ai/langgraph | GitHub | Long-running agents need durable state, human-in-the-loop checkpoints, memory, and traceable execution. |
+| Structured-prompt-programming framework, GitHub | GitHub | Treat prompts as structured modules with signatures, examples, and evaluation pressure, not as loose prose. |
+| Durable-state agent orchestration framework, GitHub | GitHub | Long-running agents need durable state, human-in-the-loop checkpoints, memory, and traceable execution. |
 | OpenAI Agents SDK guide, https://developers.openai.com/api/docs/guides/agents | official | Agent design should name instructions, tools, handoffs, guardrails, sessions, and structured outputs. |
 | OpenAI Agents SDK agents reference, https://openai.github.io/openai-agents-python/agents/ | official | Agent contracts should make tools, handoffs, guardrails, and output types explicit. |
 | Anthropic, Building Effective AI Agents, https://www.anthropic.com/engineering/building-effective-agents | professional | Keep agent systems as simple as the task allows; make prompts, tool calls, and responses inspectable. |
 | Anthropic, Writing Effective Tools for Agents, https://www.anthropic.com/engineering/writing-tools-for-agents | professional | Tool choice needs prototyping, evaluation, clear namespaces, token-efficient specs, and permission boundaries. |
-| AutoGen, https://www.microsoft.com/en-us/research/publication/autogen-enabling-next-gen-large-language-model-applications-via-multi-agent-conversation-framework/ | academic | Multi-agent teams need explicit conversation roles, tool/human integration points, and coordination contracts. |
-| CrewAI, https://github.com/crewAIInc/crewAI | GitHub | Comparable agent repos should inform role/task/handoff structure, but not replace domain research. |
+| Multi-agent conversation framework, industry publication | academic | Multi-agent teams need explicit conversation roles, tool/human integration points, and coordination contracts. |
+| Comparable multi-agent orchestration framework, GitHub | GitHub | Comparable agent repos should inform role/task/handoff structure, but not replace domain research. |
 
 ## Required Use In Builds
 

--- a/docs/robustness-protocol.md
+++ b/docs/robustness-protocol.md
@@ -18,16 +18,16 @@ baseline Hephaestus Network arm on process-aware robustness metrics.
 The protocol distills recurring patterns from public agent harnesses and local
 research notes:
 
-- Superpowers: approval before implementation, TDD, subagent execution, review,
-  and verification-before-completion.
-- GSD Core: discuss, plan, execute, verify, ship phase loops with fresh-context
-  executors and durable state files.
-- LazyCodex / oh-my-claudecode / Gajae-Code: interview, consensus planning,
+- Public agent-harness approval patterns: approval before implementation, TDD,
+  subagent execution, review, and verification-before-completion.
+- Phase-loop harness patterns: discuss, plan, execute, verify, ship phase loops
+  with fresh-context executors and durable state files.
+- Interview-driven planning harnesses: interview, consensus planning,
   goal ledgers, replay artifacts, bounded loops, and completion gates.
-- FableCodex / Fable-style operating protocol repos: requirements ledgers,
-  evidence checkpoints, final verification gates, and model-aware delegation.
-- NightWatch-style recorders: logs are claims; independent replay or artifact
-  checks are stronger proof.
+- Ledger-based operating protocols: requirements ledgers, evidence checkpoints,
+  final verification gates, and model-aware delegation.
+- Claim-verification recorder patterns: logs are claims; independent replay or
+  artifact checks are stronger proof.
 - Reflexion (<https://arxiv.org/abs/2303.11366>): failed checks become verbal
   failure memory for later attempts.
 - Self-Refine (<https://arxiv.org/abs/2303.17651>): feedback and refinement


### PR DESCRIPTION
## Summary

This PR removes specific upstream project references (insane-search, DSPy, LangGraph, AutoGen, CrewAI) and replaces them with generic descriptions of their design patterns. This change maintains the architectural inspiration and design principles while decoupling documentation and code from specific external projects.

## Key Changes

- **Documentation generalization**: Updated `robustness-protocol.md` to describe design patterns by category (e.g., "Public agent-harness approval patterns") instead of naming specific projects
- **Framework anonymization**: Replaced named framework references in `builder-quality-research-basis.md` with generic descriptions (e.g., "Structured-prompt-programming framework" instead of "DSPy")
- **Code docstring updates**: Updated module docstrings in `insane_fetch.py` across three locations to reference "external resilient public-page reader designs" instead of "insane-search"
- **Configuration anonymization**: Removed GitHub repository URL and project name from `social_fallbacks.py` upstream reference metadata, replacing with "external reference design (not disclosed)"
- **Localized documentation**: Updated Korean-language documentation in `agent-ontology-a2a-plan.md` to use generic "외부 문서 온톨로지" (external document ontology) terminology
- **Research engine documentation**: Updated `agentlas-research-engine.md` to describe the upstream design generically while preserving all functional and architectural details

## Implementation Details

- All functional behavior remains unchanged; this is purely a documentation and metadata update
- The design patterns and principles from referenced projects are preserved and documented
- Academic citations (arXiv papers, official guides) are retained as they represent peer-reviewed research
- The changes apply consistently across multiple copies of files in different plugin/adapter locations

https://claude.ai/code/session_01MY9TkfCLnoZPtvi9MDpzXb