### PR TITLE
Add SERPdive search cartridge (search.serpdive)

### DIFF
--- a/agentlas_cloud/cli.py
+++ b/agentlas_cloud/cli.py
@@ -16,18 +16,20 @@ from .runtime import AgentlasMockStore, compile_runtime_bundle, read_agent_file,
 from .update import maybe_auto_update, reconcile_adapters, run_update, write_python_shims
 
 
-RESEARCH_SEARCH_PROVIDERS = ("ddg-html", "news-rss", "github", "jina")
+RESEARCH_SEARCH_PROVIDERS = ("ddg-html", "news-rss", "github", "jina", "serpdive")
 RESEARCH_SEARCH_PROVIDER_MODULES = {
     "ddg-html": "search.ddg_html",
     "news-rss": "search.news_rss",
     "github": "search.github_repos",
     "jina": "search.jina",
+    "serpdive": "search.serpdive",
 }
 RESEARCH_SEARCH_PROVIDER_HINTS = {
     "ddg-html": "ddg_html",
     "news-rss": "news_rss",
     "github": "github",
     "jina": "jina",
+    "serpdive": "serpdive",
 }
 AGENTLAS_BROWSER_MODULE = "browser.agent_cli"
 

--- a/agentlas_cloud/networking/stormbreaker_runner.py
+++ b/agentlas_cloud/networking/stormbreaker_runner.py
@@ -51,6 +51,7 @@ STORMBREAKER_RESEARCH_MODULES = {
     "search.ddg_html",
     "search.github_repos",
     "search.jina",
+    "search.serpdive",
     "search.news_rss",
 }
 STORMBREAKER_SAFE_RESEARCH_MODULES = ["search.ddg_html", "search.news_rss", "read.http"]

--- a/agentlas_cloud/research/adapters/__init__.py
+++ b/agentlas_cloud/research/adapters/__init__.py
@@ -11,6 +11,7 @@ from .insane_fetch import InsaneFetchAdapter
 from .jina_reader import JinaReaderAdapter, JinaSearchAdapter
 from .news_rss_search import NewsRssSearchAdapter
 from .playwright_mcp import PlaywrightMcpAdapter
+from .serpdive_search import SerpdiveSearchAdapter
 from .stagehand_browser import StagehandBrowserAdapter
 from .steel_browser import SteelBrowserAdapter
 
@@ -27,6 +28,7 @@ __all__ = [
     "JinaSearchAdapter",
     "NewsRssSearchAdapter",
     "PlaywrightMcpAdapter",
+    "SerpdiveSearchAdapter",
     "StagehandBrowserAdapter",
     "SteelBrowserAdapter",
 ]

--- a/agentlas_cloud/research/adapters/serpdive_search.py
+++ b/agentlas_cloud/research/adapters/serpdive_search.py
@@ -1,0 +1,169 @@
+"""Optional SERPdive search cartridge.
+
+SERPdive returns extracted, answer-ready page content for each result rather
+than snippets. The adapter only runs when selected by policy and a key is
+configured; queries are sent to an external service.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from agentlas_cloud.networking.bootstrap import utc_now
+
+from ..contracts import ResearchAttempt, ResearchModuleManifest, ResearchRequest, ResearchResult, _stable_hash
+from ..policy import DEFAULT_MAX_BYTES
+from ..redaction import redacted_exception_reason
+
+
+SERPDIVE_SEARCH_URL = "https://api.serpdive.com/v1/search"
+
+
+class SerpdiveSearchAdapter:
+    module_id = "search.serpdive"
+    capabilities = ("search.web", "read.search_results")
+    weight = "external_light"
+    manifest = ResearchModuleManifest(
+        module_id=module_id,
+        capabilities=list(capabilities),
+        weight=weight,
+        slot="search",
+        activation="configured",
+        requires=["api_key:serpdive", "network:api.serpdive.com"],
+        permissions=["network:api.serpdive.com"],
+        default_state="available_if_configured",
+        privacy="no_raw_token_to_model; external_search_receives_query",
+        failure_modes=["module_unavailable", "rate_limited", "external_search_error", "empty_results"],
+        install_hint="Set AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY and choose provider=serpdive or loadout=full.",
+    )
+
+    def __init__(self, *, timeout_seconds: int = 30, max_bytes: int = DEFAULT_MAX_BYTES, max_results: int = 10):
+        self.timeout_seconds = timeout_seconds
+        self.max_bytes = max_bytes
+        self.max_results = max_results
+
+    def can_handle(self, source_hint: str, request: ResearchRequest) -> bool:
+        return source_hint.lower().startswith("search:serpdive:")
+
+    def read(self, source_hint: str, request: ResearchRequest) -> tuple[ResearchResult | None, ResearchAttempt]:
+        query = _search_query(source_hint)
+        if not query:
+            return None, ResearchAttempt(self.module_id, "error", "empty_serpdive_query", source_hint, weight=self.weight)
+
+        api_key = self._api_key()
+        if not api_key:
+            return (
+                None,
+                ResearchAttempt(
+                    self.module_id,
+                    "module_unavailable",
+                    "AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY not configured",
+                    source_hint,
+                    weight=self.weight,
+                ),
+            )
+
+        try:
+            payload = self._fetch_json(query, api_key=api_key)
+        except HTTPError as exc:
+            reason = _status_reason(exc.code)
+            return (
+                ResearchResult.blocked(SERPDIVE_SEARCH_URL, reason=reason),
+                ResearchAttempt(self.module_id, "blocked", f"{reason}:{exc.code}", SERPDIVE_SEARCH_URL, weight=self.weight),
+            )
+        except (URLError, TimeoutError, OSError, ValueError) as exc:
+            return (
+                None,
+                ResearchAttempt(self.module_id, "error", redacted_exception_reason(exc, max_length=160), SERPDIVE_SEARCH_URL, weight=self.weight),
+            )
+
+        title = f"SERPdive search: {query}"
+        items = _result_items(payload, max_results=self.max_results)
+        markdown = _results_markdown(items)
+        citations = [{"label": title, "url": SERPDIVE_SEARCH_URL}]
+        citations.extend({"label": item["title"] or item["url"], "url": item["url"]} for item in items)
+        result = ResearchResult(
+            source_id=_stable_hash(f"search:serpdive:{query}"),
+            url=SERPDIVE_SEARCH_URL,
+            title=title,
+            platform="web_search",
+            content_markdown=markdown,
+            extracted_at=utc_now(),
+            freshness=request.freshness,
+            confidence="usable" if markdown else "weak",
+            limits=["external_search", "serpdive_search"],
+            citations=citations,
+        )
+        return result, ResearchAttempt(self.module_id, "ok", f"serpdive_results={len(items)}", SERPDIVE_SEARCH_URL, weight=self.weight)
+
+    def _api_key(self) -> str:
+        return os.environ.get("AGENTLAS_SERPDIVE_API_KEY") or os.environ.get("SERPDIVE_API_KEY") or ""
+
+    def _fetch_json(self, query: str, *, api_key: str) -> dict:
+        body = json.dumps({"query": query, "max_results": self.max_results}).encode("utf-8")
+        req = Request(
+            SERPDIVE_SEARCH_URL,
+            data=body,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": "AgentlasResearchEngine/0.1 (+https://agentlas.cloud)",
+                "Accept": "application/json",
+            },
+            method="POST",
+        )
+        with urlopen(req, timeout=self.timeout_seconds) as resp:
+            raw = resp.read(self.max_bytes + 1)
+        parsed = json.loads(raw[: self.max_bytes].decode("utf-8", errors="replace"))
+        if not isinstance(parsed, dict):
+            raise ValueError("unexpected_serpdive_payload")
+        return parsed
+
+
+def _search_query(source_hint: str) -> str:
+    return source_hint.split(":", 2)[2].strip() if source_hint.lower().startswith("search:serpdive:") else source_hint.strip()
+
+
+def _result_items(payload: dict, *, max_results: int) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    for entry in payload.get("results") or []:
+        if not isinstance(entry, dict):
+            continue
+        url = str(entry.get("url") or "").strip()
+        if not url.startswith(("http://", "https://")):
+            continue
+        items.append(
+            {
+                "title": str(entry.get("title") or "").strip(),
+                "url": url,
+                "content": str(entry.get("content") or "").strip(),
+                "date": str(entry.get("date") or "").strip(),
+            }
+        )
+        if len(items) >= max_results:
+            break
+    return items
+
+
+def _results_markdown(items: list[dict[str, str]]) -> str:
+    sections: list[str] = []
+    for item in items:
+        heading = item["title"] or item["url"]
+        dated = f" ({item['date']})" if item["date"] else ""
+        sections.append(f"## {heading}{dated}\n{item['url']}\n\n{item['content']}".strip())
+    return "\n\n".join(sections).strip()
+
+
+def _status_reason(status: int) -> str:
+    if status in {401, 407}:
+        return "auth_required"
+    if status == 403:
+        return "blocked"
+    if status == 404:
+        return "not_found"
+    if status == 429:
+        return "rate_limited"
+    return "http_error"

--- a/agentlas_cloud/research/armory.py
+++ b/agentlas_cloud/research/armory.py
@@ -17,6 +17,7 @@ from .registry import AdapterRegistry, ResearchAdapter
 
 ENV_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     "search.jina": ("AGENTLAS_JINA_API_KEY", "JINA_API_KEY"),
+    "search.serpdive": ("AGENTLAS_SERPDIVE_API_KEY", "SERPDIVE_API_KEY"),
     "platform.reddit.oauth": ("AGENTLAS_REDDIT_BEARER_TOKEN", "REDDIT_BEARER_TOKEN"),
     "platform.threads": ("AGENTLAS_THREADS_ACCESS_TOKEN", "THREADS_ACCESS_TOKEN"),
 }

--- a/agentlas_cloud/research/doctor.py
+++ b/agentlas_cloud/research/doctor.py
@@ -127,7 +127,7 @@ def _browser_modularity_check(profile_auto: dict[str, Any], profile_browser: dic
 
 
 def _web_search_recall_check(modules: dict[str, ResearchAdapter]) -> dict[str, Any]:
-    search_modules = [module_id for module_id in ("search.ddg_html", "search.news_rss", "search.jina") if module_id in modules]
+    search_modules = [module_id for module_id in ("search.ddg_html", "search.news_rss", "search.jina", "search.serpdive") if module_id in modules]
     variants = [item["name"] for item in query_variant_catalog()]
     ok = {"search.ddg_html", "search.news_rss"}.issubset(set(search_modules)) and {"docs", "reddit", "threads", "github"}.issubset(set(variants))
     return {

--- a/agentlas_cloud/research/engine.py
+++ b/agentlas_cloud/research/engine.py
@@ -22,6 +22,7 @@ from .adapters import (
     JinaSearchAdapter,
     NewsRssSearchAdapter,
     PlaywrightMcpAdapter,
+    SerpdiveSearchAdapter,
     StagehandBrowserAdapter,
     SteelBrowserAdapter,
 )
@@ -264,6 +265,7 @@ def default_registry(*, home: Path | str | None = None) -> AdapterRegistry:
     registry.register(NewsRssSearchAdapter())
     registry.register(GitHubReposSearchAdapter())
     registry.register(JinaSearchAdapter())
+    registry.register(SerpdiveSearchAdapter())
     registry.register(HttpReaderAdapter())
     registry.register(InsaneFetchAdapter())
     registry.register(JinaReaderAdapter())
@@ -451,6 +453,7 @@ SEARCH_MODULE_HINTS = {
     "search.news_rss": "news_rss",
     "search.github_repos": "github",
     "search.jina": "jina",
+    "search.serpdive": "serpdive",
 }
 GITHUB_SEARCH_MODULE = "search.github_repos"
 GITHUB_SEARCH_KEYWORDS = ("github", "깃헙", "깃허브", "repo:", "repository", "repositories", "open source", "오픈소스")
@@ -945,6 +948,18 @@ def _escalation_advice(
                 modules=["search.jina"],
                 weight="external_light",
                 note="Configure AGENTLAS_JINA_API_KEY or JINA_API_KEY only when external search disclosure is acceptable.",
+            )
+        )
+
+    if "AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY not configured" in attempt_reasons:
+        suggestions.append(
+            _suggestion(
+                action="configure_credentials",
+                reason="serpdive_key_missing",
+                loadout="full",
+                modules=["search.serpdive"],
+                weight="external_light",
+                note="Configure AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY only when external search disclosure is acceptable.",
             )
         )
 

--- a/agentlas_cloud/research/loadouts.py
+++ b/agentlas_cloud/research/loadouts.py
@@ -19,6 +19,7 @@ AUTO_THREADS_MODULES = ("platform.threads.public",)
 AUTO_GITHUB_MODULES = ("search.github_repos",)
 AUTO_EXTERNAL_HINT_MODULES = {
     "search:jina:": "search.jina",
+    "search:serpdive:": "search.serpdive",
     "jina:": "read.jina",
 }
 GITHUB_SEARCH_KEYWORDS = ("github", "깃헙", "깃허브", "repo:", "repository", "repositories", "open source", "오픈소스")
@@ -129,6 +130,7 @@ LOADOUTS: dict[str, ResearchLoadout] = {
             "search.ddg_html",
             "search.github_repos",
             "search.jina",
+            "search.serpdive",
             "read.http",
             "read.insane_fetch",
             "read.jina",
@@ -252,7 +254,7 @@ def _auto_max_weight(request: ResearchRequest, allowed_modules: list[str]) -> st
         return "adaptive_medium"
     if _has_public_social_hint(request) and any(module in allowed_modules for module in ("platform.reddit", "platform.threads.public")):
         return "adaptive_medium"
-    if any(module in allowed_modules for module in ("search.jina", "read.jina")):
+    if any(module in allowed_modules for module in ("search.jina", "search.serpdive", "read.jina")):
         return "external_light"
     return "light"
 

--- a/agentlas_cloud/research/profile.py
+++ b/agentlas_cloud/research/profile.py
@@ -163,7 +163,7 @@ def _operator_summary(
     credential_modules = [
         module
         for module in mounted_modules
-        if module.get("id") in {"platform.reddit.oauth", "platform.threads", "search.jina"}
+        if module.get("id") in {"platform.reddit.oauth", "platform.threads", "search.jina", "search.serpdive"}
     ]
     missing_credentials = [
         module

--- a/agentlas_cloud/research/search_ranker.py
+++ b/agentlas_cloud/research/search_ranker.py
@@ -206,6 +206,9 @@ def _score_candidate(
     elif source == "search.jina":
         score += 18
         reasons.append("external_search")
+    elif source == "search.serpdive":
+        score += 18
+        reasons.append("external_search")
     elif source == "search.news_rss":
         score += 10
         reasons.append("news_search")
@@ -263,6 +266,8 @@ def _search_source(result: ResearchResult) -> str:
         return "search.github_repos"
     if "jina_search" in limits or "s.jina.ai" in url:
         return "search.jina"
+    if "serpdive_search" in limits or "api.serpdive.com" in url:
+        return "search.serpdive"
     if "public_rss_search" in limits or "news.google.com" in url:
         return "search.news_rss"
     return "search.unknown"

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/cli.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/cli.py
@@ -16,18 +16,20 @@ from .runtime import AgentlasMockStore, compile_runtime_bundle, read_agent_file,
 from .update import maybe_auto_update, reconcile_adapters, run_update, write_python_shims
 
 
-RESEARCH_SEARCH_PROVIDERS = ("ddg-html", "news-rss", "github", "jina")
+RESEARCH_SEARCH_PROVIDERS = ("ddg-html", "news-rss", "github", "jina", "serpdive")
 RESEARCH_SEARCH_PROVIDER_MODULES = {
     "ddg-html": "search.ddg_html",
     "news-rss": "search.news_rss",
     "github": "search.github_repos",
     "jina": "search.jina",
+    "serpdive": "search.serpdive",
 }
 RESEARCH_SEARCH_PROVIDER_HINTS = {
     "ddg-html": "ddg_html",
     "news-rss": "news_rss",
     "github": "github",
     "jina": "jina",
+    "serpdive": "serpdive",
 }
 AGENTLAS_BROWSER_MODULE = "browser.agent_cli"
 

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/stormbreaker_runner.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/stormbreaker_runner.py
@@ -51,6 +51,7 @@ STORMBREAKER_RESEARCH_MODULES = {
     "search.ddg_html",
     "search.github_repos",
     "search.jina",
+    "search.serpdive",
     "search.news_rss",
 }
 STORMBREAKER_SAFE_RESEARCH_MODULES = ["search.ddg_html", "search.news_rss", "read.http"]

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/__init__.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/__init__.py
@@ -11,6 +11,7 @@ from .insane_fetch import InsaneFetchAdapter
 from .jina_reader import JinaReaderAdapter, JinaSearchAdapter
 from .news_rss_search import NewsRssSearchAdapter
 from .playwright_mcp import PlaywrightMcpAdapter
+from .serpdive_search import SerpdiveSearchAdapter
 from .stagehand_browser import StagehandBrowserAdapter
 from .steel_browser import SteelBrowserAdapter
 
@@ -27,6 +28,7 @@ __all__ = [
     "JinaSearchAdapter",
     "NewsRssSearchAdapter",
     "PlaywrightMcpAdapter",
+    "SerpdiveSearchAdapter",
     "StagehandBrowserAdapter",
     "SteelBrowserAdapter",
 ]

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/serpdive_search.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/serpdive_search.py
@@ -1,0 +1,169 @@
+"""Optional SERPdive search cartridge.
+
+SERPdive returns extracted, answer-ready page content for each result rather
+than snippets. The adapter only runs when selected by policy and a key is
+configured; queries are sent to an external service.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from agentlas_cloud.networking.bootstrap import utc_now
+
+from ..contracts import ResearchAttempt, ResearchModuleManifest, ResearchRequest, ResearchResult, _stable_hash
+from ..policy import DEFAULT_MAX_BYTES
+from ..redaction import redacted_exception_reason
+
+
+SERPDIVE_SEARCH_URL = "https://api.serpdive.com/v1/search"
+
+
+class SerpdiveSearchAdapter:
+    module_id = "search.serpdive"
+    capabilities = ("search.web", "read.search_results")
+    weight = "external_light"
+    manifest = ResearchModuleManifest(
+        module_id=module_id,
+        capabilities=list(capabilities),
+        weight=weight,
+        slot="search",
+        activation="configured",
+        requires=["api_key:serpdive", "network:api.serpdive.com"],
+        permissions=["network:api.serpdive.com"],
+        default_state="available_if_configured",
+        privacy="no_raw_token_to_model; external_search_receives_query",
+        failure_modes=["module_unavailable", "rate_limited", "external_search_error", "empty_results"],
+        install_hint="Set AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY and choose provider=serpdive or loadout=full.",
+    )
+
+    def __init__(self, *, timeout_seconds: int = 30, max_bytes: int = DEFAULT_MAX_BYTES, max_results: int = 10):
+        self.timeout_seconds = timeout_seconds
+        self.max_bytes = max_bytes
+        self.max_results = max_results
+
+    def can_handle(self, source_hint: str, request: ResearchRequest) -> bool:
+        return source_hint.lower().startswith("search:serpdive:")
+
+    def read(self, source_hint: str, request: ResearchRequest) -> tuple[ResearchResult | None, ResearchAttempt]:
+        query = _search_query(source_hint)
+        if not query:
+            return None, ResearchAttempt(self.module_id, "error", "empty_serpdive_query", source_hint, weight=self.weight)
+
+        api_key = self._api_key()
+        if not api_key:
+            return (
+                None,
+                ResearchAttempt(
+                    self.module_id,
+                    "module_unavailable",
+                    "AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY not configured",
+                    source_hint,
+                    weight=self.weight,
+                ),
+            )
+
+        try:
+            payload = self._fetch_json(query, api_key=api_key)
+        except HTTPError as exc:
+            reason = _status_reason(exc.code)
+            return (
+                ResearchResult.blocked(SERPDIVE_SEARCH_URL, reason=reason),
+                ResearchAttempt(self.module_id, "blocked", f"{reason}:{exc.code}", SERPDIVE_SEARCH_URL, weight=self.weight),
+            )
+        except (URLError, TimeoutError, OSError, ValueError) as exc:
+            return (
+                None,
+                ResearchAttempt(self.module_id, "error", redacted_exception_reason(exc, max_length=160), SERPDIVE_SEARCH_URL, weight=self.weight),
+            )
+
+        title = f"SERPdive search: {query}"
+        items = _result_items(payload, max_results=self.max_results)
+        markdown = _results_markdown(items)
+        citations = [{"label": title, "url": SERPDIVE_SEARCH_URL}]
+        citations.extend({"label": item["title"] or item["url"], "url": item["url"]} for item in items)
+        result = ResearchResult(
+            source_id=_stable_hash(f"search:serpdive:{query}"),
+            url=SERPDIVE_SEARCH_URL,
+            title=title,
+            platform="web_search",
+            content_markdown=markdown,
+            extracted_at=utc_now(),
+            freshness=request.freshness,
+            confidence="usable" if markdown else "weak",
+            limits=["external_search", "serpdive_search"],
+            citations=citations,
+        )
+        return result, ResearchAttempt(self.module_id, "ok", f"serpdive_results={len(items)}", SERPDIVE_SEARCH_URL, weight=self.weight)
+
+    def _api_key(self) -> str:
+        return os.environ.get("AGENTLAS_SERPDIVE_API_KEY") or os.environ.get("SERPDIVE_API_KEY") or ""
+
+    def _fetch_json(self, query: str, *, api_key: str) -> dict:
+        body = json.dumps({"query": query, "max_results": self.max_results}).encode("utf-8")
+        req = Request(
+            SERPDIVE_SEARCH_URL,
+            data=body,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": "AgentlasResearchEngine/0.1 (+https://agentlas.cloud)",
+                "Accept": "application/json",
+            },
+            method="POST",
+        )
+        with urlopen(req, timeout=self.timeout_seconds) as resp:
+            raw = resp.read(self.max_bytes + 1)
+        parsed = json.loads(raw[: self.max_bytes].decode("utf-8", errors="replace"))
+        if not isinstance(parsed, dict):
+            raise ValueError("unexpected_serpdive_payload")
+        return parsed
+
+
+def _search_query(source_hint: str) -> str:
+    return source_hint.split(":", 2)[2].strip() if source_hint.lower().startswith("search:serpdive:") else source_hint.strip()
+
+
+def _result_items(payload: dict, *, max_results: int) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    for entry in payload.get("results") or []:
+        if not isinstance(entry, dict):
+            continue
+        url = str(entry.get("url") or "").strip()
+        if not url.startswith(("http://", "https://")):
+            continue
+        items.append(
+            {
+                "title": str(entry.get("title") or "").strip(),
+                "url": url,
+                "content": str(entry.get("content") or "").strip(),
+                "date": str(entry.get("date") or "").strip(),
+            }
+        )
+        if len(items) >= max_results:
+            break
+    return items
+
+
+def _results_markdown(items: list[dict[str, str]]) -> str:
+    sections: list[str] = []
+    for item in items:
+        heading = item["title"] or item["url"]
+        dated = f" ({item['date']})" if item["date"] else ""
+        sections.append(f"## {heading}{dated}\n{item['url']}\n\n{item['content']}".strip())
+    return "\n\n".join(sections).strip()
+
+
+def _status_reason(status: int) -> str:
+    if status in {401, 407}:
+        return "auth_required"
+    if status == 403:
+        return "blocked"
+    if status == 404:
+        return "not_found"
+    if status == 429:
+        return "rate_limited"
+    return "http_error"

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/armory.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/armory.py
@@ -17,6 +17,7 @@ from .registry import AdapterRegistry, ResearchAdapter
 
 ENV_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     "search.jina": ("AGENTLAS_JINA_API_KEY", "JINA_API_KEY"),
+    "search.serpdive": ("AGENTLAS_SERPDIVE_API_KEY", "SERPDIVE_API_KEY"),
     "platform.reddit.oauth": ("AGENTLAS_REDDIT_BEARER_TOKEN", "REDDIT_BEARER_TOKEN"),
     "platform.threads": ("AGENTLAS_THREADS_ACCESS_TOKEN", "THREADS_ACCESS_TOKEN"),
 }

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/doctor.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/doctor.py
@@ -127,7 +127,7 @@ def _browser_modularity_check(profile_auto: dict[str, Any], profile_browser: dic
 
 
 def _web_search_recall_check(modules: dict[str, ResearchAdapter]) -> dict[str, Any]:
-    search_modules = [module_id for module_id in ("search.ddg_html", "search.news_rss", "search.jina") if module_id in modules]
+    search_modules = [module_id for module_id in ("search.ddg_html", "search.news_rss", "search.jina", "search.serpdive") if module_id in modules]
     variants = [item["name"] for item in query_variant_catalog()]
     ok = {"search.ddg_html", "search.news_rss"}.issubset(set(search_modules)) and {"docs", "reddit", "threads", "github"}.issubset(set(variants))
     return {

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/engine.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/engine.py
@@ -22,6 +22,7 @@ from .adapters import (
     JinaSearchAdapter,
     NewsRssSearchAdapter,
     PlaywrightMcpAdapter,
+    SerpdiveSearchAdapter,
     StagehandBrowserAdapter,
     SteelBrowserAdapter,
 )
@@ -264,6 +265,7 @@ def default_registry(*, home: Path | str | None = None) -> AdapterRegistry:
     registry.register(NewsRssSearchAdapter())
     registry.register(GitHubReposSearchAdapter())
     registry.register(JinaSearchAdapter())
+    registry.register(SerpdiveSearchAdapter())
     registry.register(HttpReaderAdapter())
     registry.register(InsaneFetchAdapter())
     registry.register(JinaReaderAdapter())
@@ -451,6 +453,7 @@ SEARCH_MODULE_HINTS = {
     "search.news_rss": "news_rss",
     "search.github_repos": "github",
     "search.jina": "jina",
+    "search.serpdive": "serpdive",
 }
 GITHUB_SEARCH_MODULE = "search.github_repos"
 GITHUB_SEARCH_KEYWORDS = ("github", "깃헙", "깃허브", "repo:", "repository", "repositories", "open source", "오픈소스")
@@ -945,6 +948,18 @@ def _escalation_advice(
                 modules=["search.jina"],
                 weight="external_light",
                 note="Configure AGENTLAS_JINA_API_KEY or JINA_API_KEY only when external search disclosure is acceptable.",
+            )
+        )
+
+    if "AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY not configured" in attempt_reasons:
+        suggestions.append(
+            _suggestion(
+                action="configure_credentials",
+                reason="serpdive_key_missing",
+                loadout="full",
+                modules=["search.serpdive"],
+                weight="external_light",
+                note="Configure AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY only when external search disclosure is acceptable.",
             )
         )
 

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/loadouts.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/loadouts.py
@@ -19,6 +19,7 @@ AUTO_THREADS_MODULES = ("platform.threads.public",)
 AUTO_GITHUB_MODULES = ("search.github_repos",)
 AUTO_EXTERNAL_HINT_MODULES = {
     "search:jina:": "search.jina",
+    "search:serpdive:": "search.serpdive",
     "jina:": "read.jina",
 }
 GITHUB_SEARCH_KEYWORDS = ("github", "깃헙", "깃허브", "repo:", "repository", "repositories", "open source", "오픈소스")
@@ -129,6 +130,7 @@ LOADOUTS: dict[str, ResearchLoadout] = {
             "search.ddg_html",
             "search.github_repos",
             "search.jina",
+            "search.serpdive",
             "read.http",
             "read.insane_fetch",
             "read.jina",
@@ -252,7 +254,7 @@ def _auto_max_weight(request: ResearchRequest, allowed_modules: list[str]) -> st
         return "adaptive_medium"
     if _has_public_social_hint(request) and any(module in allowed_modules for module in ("platform.reddit", "platform.threads.public")):
         return "adaptive_medium"
-    if any(module in allowed_modules for module in ("search.jina", "read.jina")):
+    if any(module in allowed_modules for module in ("search.jina", "search.serpdive", "read.jina")):
         return "external_light"
     return "light"
 

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/profile.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/profile.py
@@ -163,7 +163,7 @@ def _operator_summary(
     credential_modules = [
         module
         for module in mounted_modules
-        if module.get("id") in {"platform.reddit.oauth", "platform.threads", "search.jina"}
+        if module.get("id") in {"platform.reddit.oauth", "platform.threads", "search.jina", "search.serpdive"}
     ]
     missing_credentials = [
         module

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/search_ranker.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/search_ranker.py
@@ -206,6 +206,9 @@ def _score_candidate(
     elif source == "search.jina":
         score += 18
         reasons.append("external_search")
+    elif source == "search.serpdive":
+        score += 18
+        reasons.append("external_search")
     elif source == "search.news_rss":
         score += 10
         reasons.append("news_search")
@@ -263,6 +266,8 @@ def _search_source(result: ResearchResult) -> str:
         return "search.github_repos"
     if "jina_search" in limits or "s.jina.ai" in url:
         return "search.jina"
+    if "serpdive_search" in limits or "api.serpdive.com" in url:
+        return "search.serpdive"
     if "public_rss_search" in limits or "news.google.com" in url:
         return "search.news_rss"
     return "search.unknown"

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/cli.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/cli.py
@@ -16,18 +16,20 @@ from .runtime import AgentlasMockStore, compile_runtime_bundle, read_agent_file,
 from .update import maybe_auto_update, reconcile_adapters, run_update, write_python_shims
 
 
-RESEARCH_SEARCH_PROVIDERS = ("ddg-html", "news-rss", "github", "jina")
+RESEARCH_SEARCH_PROVIDERS = ("ddg-html", "news-rss", "github", "jina", "serpdive")
 RESEARCH_SEARCH_PROVIDER_MODULES = {
     "ddg-html": "search.ddg_html",
     "news-rss": "search.news_rss",
     "github": "search.github_repos",
     "jina": "search.jina",
+    "serpdive": "search.serpdive",
 }
 RESEARCH_SEARCH_PROVIDER_HINTS = {
     "ddg-html": "ddg_html",
     "news-rss": "news_rss",
     "github": "github",
     "jina": "jina",
+    "serpdive": "serpdive",
 }
 AGENTLAS_BROWSER_MODULE = "browser.agent_cli"
 

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/stormbreaker_runner.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/stormbreaker_runner.py
@@ -51,6 +51,7 @@ STORMBREAKER_RESEARCH_MODULES = {
     "search.ddg_html",
     "search.github_repos",
     "search.jina",
+    "search.serpdive",
     "search.news_rss",
 }
 STORMBREAKER_SAFE_RESEARCH_MODULES = ["search.ddg_html", "search.news_rss", "read.http"]

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/__init__.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/__init__.py
@@ -11,6 +11,7 @@ from .insane_fetch import InsaneFetchAdapter
 from .jina_reader import JinaReaderAdapter, JinaSearchAdapter
 from .news_rss_search import NewsRssSearchAdapter
 from .playwright_mcp import PlaywrightMcpAdapter
+from .serpdive_search import SerpdiveSearchAdapter
 from .stagehand_browser import StagehandBrowserAdapter
 from .steel_browser import SteelBrowserAdapter
 
@@ -27,6 +28,7 @@ __all__ = [
     "JinaSearchAdapter",
     "NewsRssSearchAdapter",
     "PlaywrightMcpAdapter",
+    "SerpdiveSearchAdapter",
     "StagehandBrowserAdapter",
     "SteelBrowserAdapter",
 ]

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/serpdive_search.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/serpdive_search.py
@@ -1,0 +1,169 @@
+"""Optional SERPdive search cartridge.
+
+SERPdive returns extracted, answer-ready page content for each result rather
+than snippets. The adapter only runs when selected by policy and a key is
+configured; queries are sent to an external service.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from agentlas_cloud.networking.bootstrap import utc_now
+
+from ..contracts import ResearchAttempt, ResearchModuleManifest, ResearchRequest, ResearchResult, _stable_hash
+from ..policy import DEFAULT_MAX_BYTES
+from ..redaction import redacted_exception_reason
+
+
+SERPDIVE_SEARCH_URL = "https://api.serpdive.com/v1/search"
+
+
+class SerpdiveSearchAdapter:
+    module_id = "search.serpdive"
+    capabilities = ("search.web", "read.search_results")
+    weight = "external_light"
+    manifest = ResearchModuleManifest(
+        module_id=module_id,
+        capabilities=list(capabilities),
+        weight=weight,
+        slot="search",
+        activation="configured",
+        requires=["api_key:serpdive", "network:api.serpdive.com"],
+        permissions=["network:api.serpdive.com"],
+        default_state="available_if_configured",
+        privacy="no_raw_token_to_model; external_search_receives_query",
+        failure_modes=["module_unavailable", "rate_limited", "external_search_error", "empty_results"],
+        install_hint="Set AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY and choose provider=serpdive or loadout=full.",
+    )
+
+    def __init__(self, *, timeout_seconds: int = 30, max_bytes: int = DEFAULT_MAX_BYTES, max_results: int = 10):
+        self.timeout_seconds = timeout_seconds
+        self.max_bytes = max_bytes
+        self.max_results = max_results
+
+    def can_handle(self, source_hint: str, request: ResearchRequest) -> bool:
+        return source_hint.lower().startswith("search:serpdive:")
+
+    def read(self, source_hint: str, request: ResearchRequest) -> tuple[ResearchResult | None, ResearchAttempt]:
+        query = _search_query(source_hint)
+        if not query:
+            return None, ResearchAttempt(self.module_id, "error", "empty_serpdive_query", source_hint, weight=self.weight)
+
+        api_key = self._api_key()
+        if not api_key:
+            return (
+                None,
+                ResearchAttempt(
+                    self.module_id,
+                    "module_unavailable",
+                    "AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY not configured",
+                    source_hint,
+                    weight=self.weight,
+                ),
+            )
+
+        try:
+            payload = self._fetch_json(query, api_key=api_key)
+        except HTTPError as exc:
+            reason = _status_reason(exc.code)
+            return (
+                ResearchResult.blocked(SERPDIVE_SEARCH_URL, reason=reason),
+                ResearchAttempt(self.module_id, "blocked", f"{reason}:{exc.code}", SERPDIVE_SEARCH_URL, weight=self.weight),
+            )
+        except (URLError, TimeoutError, OSError, ValueError) as exc:
+            return (
+                None,
+                ResearchAttempt(self.module_id, "error", redacted_exception_reason(exc, max_length=160), SERPDIVE_SEARCH_URL, weight=self.weight),
+            )
+
+        title = f"SERPdive search: {query}"
+        items = _result_items(payload, max_results=self.max_results)
+        markdown = _results_markdown(items)
+        citations = [{"label": title, "url": SERPDIVE_SEARCH_URL}]
+        citations.extend({"label": item["title"] or item["url"], "url": item["url"]} for item in items)
+        result = ResearchResult(
+            source_id=_stable_hash(f"search:serpdive:{query}"),
+            url=SERPDIVE_SEARCH_URL,
+            title=title,
+            platform="web_search",
+            content_markdown=markdown,
+            extracted_at=utc_now(),
+            freshness=request.freshness,
+            confidence="usable" if markdown else "weak",
+            limits=["external_search", "serpdive_search"],
+            citations=citations,
+        )
+        return result, ResearchAttempt(self.module_id, "ok", f"serpdive_results={len(items)}", SERPDIVE_SEARCH_URL, weight=self.weight)
+
+    def _api_key(self) -> str:
+        return os.environ.get("AGENTLAS_SERPDIVE_API_KEY") or os.environ.get("SERPDIVE_API_KEY") or ""
+
+    def _fetch_json(self, query: str, *, api_key: str) -> dict:
+        body = json.dumps({"query": query, "max_results": self.max_results}).encode("utf-8")
+        req = Request(
+            SERPDIVE_SEARCH_URL,
+            data=body,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": "AgentlasResearchEngine/0.1 (+https://agentlas.cloud)",
+                "Accept": "application/json",
+            },
+            method="POST",
+        )
+        with urlopen(req, timeout=self.timeout_seconds) as resp:
+            raw = resp.read(self.max_bytes + 1)
+        parsed = json.loads(raw[: self.max_bytes].decode("utf-8", errors="replace"))
+        if not isinstance(parsed, dict):
+            raise ValueError("unexpected_serpdive_payload")
+        return parsed
+
+
+def _search_query(source_hint: str) -> str:
+    return source_hint.split(":", 2)[2].strip() if source_hint.lower().startswith("search:serpdive:") else source_hint.strip()
+
+
+def _result_items(payload: dict, *, max_results: int) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    for entry in payload.get("results") or []:
+        if not isinstance(entry, dict):
+            continue
+        url = str(entry.get("url") or "").strip()
+        if not url.startswith(("http://", "https://")):
+            continue
+        items.append(
+            {
+                "title": str(entry.get("title") or "").strip(),
+                "url": url,
+                "content": str(entry.get("content") or "").strip(),
+                "date": str(entry.get("date") or "").strip(),
+            }
+        )
+        if len(items) >= max_results:
+            break
+    return items
+
+
+def _results_markdown(items: list[dict[str, str]]) -> str:
+    sections: list[str] = []
+    for item in items:
+        heading = item["title"] or item["url"]
+        dated = f" ({item['date']})" if item["date"] else ""
+        sections.append(f"## {heading}{dated}\n{item['url']}\n\n{item['content']}".strip())
+    return "\n\n".join(sections).strip()
+
+
+def _status_reason(status: int) -> str:
+    if status in {401, 407}:
+        return "auth_required"
+    if status == 403:
+        return "blocked"
+    if status == 404:
+        return "not_found"
+    if status == 429:
+        return "rate_limited"
+    return "http_error"

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/armory.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/armory.py
@@ -17,6 +17,7 @@ from .registry import AdapterRegistry, ResearchAdapter
 
 ENV_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     "search.jina": ("AGENTLAS_JINA_API_KEY", "JINA_API_KEY"),
+    "search.serpdive": ("AGENTLAS_SERPDIVE_API_KEY", "SERPDIVE_API_KEY"),
     "platform.reddit.oauth": ("AGENTLAS_REDDIT_BEARER_TOKEN", "REDDIT_BEARER_TOKEN"),
     "platform.threads": ("AGENTLAS_THREADS_ACCESS_TOKEN", "THREADS_ACCESS_TOKEN"),
 }

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/doctor.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/doctor.py
@@ -127,7 +127,7 @@ def _browser_modularity_check(profile_auto: dict[str, Any], profile_browser: dic
 
 
 def _web_search_recall_check(modules: dict[str, ResearchAdapter]) -> dict[str, Any]:
-    search_modules = [module_id for module_id in ("search.ddg_html", "search.news_rss", "search.jina") if module_id in modules]
+    search_modules = [module_id for module_id in ("search.ddg_html", "search.news_rss", "search.jina", "search.serpdive") if module_id in modules]
     variants = [item["name"] for item in query_variant_catalog()]
     ok = {"search.ddg_html", "search.news_rss"}.issubset(set(search_modules)) and {"docs", "reddit", "threads", "github"}.issubset(set(variants))
     return {

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/engine.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/engine.py
@@ -22,6 +22,7 @@ from .adapters import (
     JinaSearchAdapter,
     NewsRssSearchAdapter,
     PlaywrightMcpAdapter,
+    SerpdiveSearchAdapter,
     StagehandBrowserAdapter,
     SteelBrowserAdapter,
 )
@@ -264,6 +265,7 @@ def default_registry(*, home: Path | str | None = None) -> AdapterRegistry:
     registry.register(NewsRssSearchAdapter())
     registry.register(GitHubReposSearchAdapter())
     registry.register(JinaSearchAdapter())
+    registry.register(SerpdiveSearchAdapter())
     registry.register(HttpReaderAdapter())
     registry.register(InsaneFetchAdapter())
     registry.register(JinaReaderAdapter())
@@ -451,6 +453,7 @@ SEARCH_MODULE_HINTS = {
     "search.news_rss": "news_rss",
     "search.github_repos": "github",
     "search.jina": "jina",
+    "search.serpdive": "serpdive",
 }
 GITHUB_SEARCH_MODULE = "search.github_repos"
 GITHUB_SEARCH_KEYWORDS = ("github", "깃헙", "깃허브", "repo:", "repository", "repositories", "open source", "오픈소스")
@@ -945,6 +948,18 @@ def _escalation_advice(
                 modules=["search.jina"],
                 weight="external_light",
                 note="Configure AGENTLAS_JINA_API_KEY or JINA_API_KEY only when external search disclosure is acceptable.",
+            )
+        )
+
+    if "AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY not configured" in attempt_reasons:
+        suggestions.append(
+            _suggestion(
+                action="configure_credentials",
+                reason="serpdive_key_missing",
+                loadout="full",
+                modules=["search.serpdive"],
+                weight="external_light",
+                note="Configure AGENTLAS_SERPDIVE_API_KEY or SERPDIVE_API_KEY only when external search disclosure is acceptable.",
             )
         )
 

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/loadouts.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/loadouts.py
@@ -19,6 +19,7 @@ AUTO_THREADS_MODULES = ("platform.threads.public",)
 AUTO_GITHUB_MODULES = ("search.github_repos",)
 AUTO_EXTERNAL_HINT_MODULES = {
     "search:jina:": "search.jina",
+    "search:serpdive:": "search.serpdive",
     "jina:": "read.jina",
 }
 GITHUB_SEARCH_KEYWORDS = ("github", "깃헙", "깃허브", "repo:", "repository", "repositories", "open source", "오픈소스")
@@ -129,6 +130,7 @@ LOADOUTS: dict[str, ResearchLoadout] = {
             "search.ddg_html",
             "search.github_repos",
             "search.jina",
+            "search.serpdive",
             "read.http",
             "read.insane_fetch",
             "read.jina",
@@ -252,7 +254,7 @@ def _auto_max_weight(request: ResearchRequest, allowed_modules: list[str]) -> st
         return "adaptive_medium"
     if _has_public_social_hint(request) and any(module in allowed_modules for module in ("platform.reddit", "platform.threads.public")):
         return "adaptive_medium"
-    if any(module in allowed_modules for module in ("search.jina", "read.jina")):
+    if any(module in allowed_modules for module in ("search.jina", "search.serpdive", "read.jina")):
         return "external_light"
     return "light"
 

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/profile.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/profile.py
@@ -163,7 +163,7 @@ def _operator_summary(
     credential_modules = [
         module
         for module in mounted_modules
-        if module.get("id") in {"platform.reddit.oauth", "platform.threads", "search.jina"}
+        if module.get("id") in {"platform.reddit.oauth", "platform.threads", "search.jina", "search.serpdive"}
     ]
     missing_credentials = [
         module

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/search_ranker.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/search_ranker.py
@@ -206,6 +206,9 @@ def _score_candidate(
     elif source == "search.jina":
         score += 18
         reasons.append("external_search")
+    elif source == "search.serpdive":
+        score += 18
+        reasons.append("external_search")
     elif source == "search.news_rss":
         score += 10
         reasons.append("news_search")
@@ -263,6 +266,8 @@ def _search_source(result: ResearchResult) -> str:
         return "search.github_repos"
     if "jina_search" in limits or "s.jina.ai" in url:
         return "search.jina"
+    if "serpdive_search" in limits or "api.serpdive.com" in url:
+        return "search.serpdive"
     if "public_rss_search" in limits or "news.google.com" in url:
         return "search.news_rss"
     return "search.unknown"

--- a/docs/agentlas-research-engine.md
+++ b/docs/agentlas-research-engine.md
@@ -509,6 +509,7 @@ bounded search follow-up through the built-in registry:
 | `search.news_rss` | `light` | available | No-key public RSS search for current/news-like web discovery. |
 | `search.github_repos` | `light` | available | No-key GitHub REST repository search for public repo discovery. It is mounted by `public-web`/`full`, but auto fan-out uses it only for GitHub hints or explicit `--provider github`. |
 | `search.jina` | `external_light` | available if configured | Jina web search cartridge for explicit `research search` calls; requires `AGENTLAS_JINA_API_KEY` or `JINA_API_KEY`. |
+| `search.serpdive` | `external_light` | available if configured | SERPdive web search cartridge returning extracted, answer-ready page content per result; requires `AGENTLAS_SERPDIVE_API_KEY` or `SERPDIVE_API_KEY`. |
 | `read.http` | `light` | available | Safe static HTTP/HTML reader. |
 | `read.insane_fetch` | `adaptive_medium` | available if allowed | Bounded public-route fetch-chain inspired by an external resilient-reader design: direct read, Reddit `.rss`, Jina Reader fallback, metadata/feed parsing, route trace evidence, and hard stop on login/paywall. This stays a detachable public reader, not the core research engine. |
 | `read.jina` | `external_light` | available if allowed | Jina Reader URL-to-markdown cartridge; plain URL reads are not sent to Jina unless this module is explicitly allowed. |
@@ -667,6 +668,13 @@ Search through the Jina cartridge when a key is configured:
 ```bash
 AGENTLAS_JINA_API_KEY=... bin/hephaestus research search "agent browser modular research" \
   --provider jina
+```
+
+Search through the SERPdive cartridge when a key is configured:
+
+```bash
+AGENTLAS_SERPDIVE_API_KEY=... bin/hephaestus research search "agent browser modular research" \
+  --provider serpdive
 ```
 
 List detachable modules:


### PR DESCRIPTION
## What

Adds a `search.serpdive` cartridge, mirroring `search.jina`: `configured` activation behind `AGENTLAS_SERPDIVE_API_KEY` / `SERPDIVE_API_KEY`, `external_light` weight, `search:serpdive:` source hint, `--provider serpdive`, mounted by the `full` loadout only.

[SERPdive](https://serpdive.com) returns extracted, answer-ready page content per result rather than snippets — each result arrives as citable content, which maps well onto `content_markdown` + citations. On a [public 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark) it won 60.7% of decided quality duels against Tavily's default (basic) search while returning 20.2% fewer tokens (1,001 vs 1,255 per query on average) at the same speed; the advanced Tavily tier was untested. Free tier, no card.

Full disclosure: I built SERPdive. If an external keyed search cartridge isn't something you want in-tree, feel free to close — no hard feelings.

## How

Every touchpoint mirrors the `search.jina` precedent, same doctrine (query disclosure noted in `privacy`, no mount outside `full`, key-missing surfaces as `module_unavailable` with a `configure_credentials` suggestion):

- `adapters/serpdive_search.py` — stdlib-only POST to `api.serpdive.com/v1/search`, bounded read, redacted errors, results → markdown sections + citations
- registration: `adapters/__init__`, engine registry + `SEARCH_MODULE_HINTS`, CLI provider maps, loadouts (`full` + hint prefix + weight), armory env keys, doctor, profile credential set, search_ranker classification (same `external_search` score as jina), stormbreaker allowlist
- docs: module table row + CLI example
- plugin mirrors re-rendered with `scripts/sync-adapters.sh`; `scripts/public_safety_check.sh` passes

## Testing

Exercised the adapter directly (stubbed transport): result mapping/citations, the no-key `module_unavailable` path, ranker classification, and armory readiness reporting for `search.serpdive`. Happy to adjust anything to fit conventions I've missed.
