### PR TITLE
i18n: translate explanatory code comments to English

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,8 @@ test-results/
 # self-enforce the runtime allowlist (no tests/credentials enter the download).
 scripts/ao-gate.sh
 scripts/bump-version.sh
+scripts/changelog-sync.mjs
+.changelog-sync-cursor.json
 scripts/install-main-only-git-guard.sh
 scripts/run-one-touch-terminal.command
 scripts/score-robustness-eval.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,22 @@ localized marketplace fields, trigger examples, and sample user inputs. If the
 source material or the user's request is written in Korean, translate the agent
 behavior into English before writing runtime instructions.
 
+## Source Code & Commit Language
+
+This is a public, open-source repository. Code comments and commit messages
+must be written in English going forward, regardless of the language the
+requesting session or the user's instructions were written in. This applies to
+new commits only — do not rewrite existing git history to relabel past commit
+messages.
+
+Exempt from this rule (leave as-is, do not force-translate): localized
+marketplace/product copy, Korean sample inputs used as routing or i18n test
+fixtures (e.g. `"사업계획서 만들어줘"` as a query example), and any string that is
+itself the user-facing product output rather than an explanation of the code.
+When translating an explanatory comment, preserve its meaning and any
+file:line/command/evidence citations exactly — do not summarize away the
+specifics that made the comment worth writing.
+
 ## Operating Loop
 
 Before applying the package-building loop below, preserve the product runtime

--- a/agentlas_cloud/brief/shape.py
+++ b/agentlas_cloud/brief/shape.py
@@ -31,7 +31,7 @@ __all__ = ["classify_shape", "find_row_verdict", "SHAPES"]
 SHAPES = ("ledger", "verdict", "dossier", "computation", "blueprint", "rendition", "other")
 
 # A judgement property is one whose value space is a small closed set. The name is
-# irrelevant - `severity`, `status`, `verdict`, `등급` and `risk_tier` all qualify by
+# irrelevant - `severity`, `status`, `verdict`, `grade` and `risk_tier` all qualify by
 # having few allowed values, and a free-text field never does however it is named.
 _MAX_VERDICT_VALUES = 12
 

--- a/agentlas_cloud/cli.py
+++ b/agentlas_cloud/cli.py
@@ -445,7 +445,7 @@ def main(argv: list[str] | None = None) -> int:
         "--scope",
         choices=["network", "cloud"],
         default="network",
-        help="network = public Hub marketplace; cloud = the signed-in owner's OWN cloud packages (보관함). cloud implies --hub-only (/hep-cloud).",
+        help="network = public Hub marketplace; cloud = the signed-in owner's OWN cloud packages. cloud implies --hub-only (/hep-cloud).",
     )
     route.add_argument(
         "--caller",
@@ -1014,8 +1014,8 @@ def main(argv: list[str] | None = None) -> int:
             # contracts, project-soul-memory.md, credentials/ and signing/
             # scaffolding — and rewrote .gitignore, with no consent and no notice.
             # Terminal already refuses to do this (it calls its own boundary with
-            # "read" permission and comments "context 명령은 프로젝트를 초기화하지
-            # 않는다"); Core was overriding that boundary from underneath.
+            # "read" permission and comments "the context command does not
+            # initialize a project"); Core was overriding that boundary from underneath.
             # Refresh an existing project, never conjure a new one.
             already_initialized = bool(
                 (Path(args.project).expanduser().resolve() / ".agentlas").is_dir()

--- a/agentlas_cloud/interview/lenses.py
+++ b/agentlas_cloud/interview/lenses.py
@@ -15,28 +15,28 @@ from typing import Any
 
 LENS_GROUPS: dict[str, list[dict[str, str]]] = {
     "scope": [
-        {"id": "negative_space", "find": "언급되지 않은 인접 영역", "ko": "X는 언급 안 하셨는데, 의도적으로 뺀 건가요?", "en": "You didn't mention X — deliberately out of scope?"},
-        {"id": "minimum_version", "find": "과설계", "ko": "80%를 해결하는 가장 작은 버전은 뭔가요?", "en": "What is the smallest version that solves 80%?"},
-        {"id": "anti_scope", "find": "하면 안 되는 인접 작업 (anti_triggers 원천)", "ko": "비슷해 보여도 '이건 하면 안 된다'가 있다면요?", "en": "Anything that looks similar but must NOT be done?"},
-        {"id": "done_signal", "find": "끝의 정의", "ko": "뭘 보면 '됐다'고 판단하실 건가요?", "en": "What will you look at to call this done?"},
+        {"id": "negative_space", "find": "unmentioned adjacent area", "ko": "X는 언급 안 하셨는데, 의도적으로 뺀 건가요?", "en": "You didn't mention X — deliberately out of scope?"},
+        {"id": "minimum_version", "find": "over-engineering", "ko": "80%를 해결하는 가장 작은 버전은 뭔가요?", "en": "What is the smallest version that solves 80%?"},
+        {"id": "anti_scope", "find": "adjacent work that must not be done (source of anti_triggers)", "ko": "비슷해 보여도 '이건 하면 안 된다'가 있다면요?", "en": "Anything that looks similar but must NOT be done?"},
+        {"id": "done_signal", "find": "definition of done", "ko": "뭘 보면 '됐다'고 판단하실 건가요?", "en": "What will you look at to call this done?"},
     ],
     "system": [
-        {"id": "dependency_chain", "find": "숨은 결합", "ko": "X가 실패하면 같이 부서지는 게 뭔가요?", "en": "If X fails, what breaks with it?"},
-        {"id": "existing_assets", "find": "중복 구축", "ko": "이미 있는 Y를 확장할까요, 새로 만들까요?", "en": "Extend the existing Y, or build new?"},
-        {"id": "time_horizon", "find": "단기 해법의 부채", "ko": "3개월 뒤에도 이 결정이 유효한가요?", "en": "Will this decision still hold in 3 months?"},
-        {"id": "failure_mode", "find": "예외 경로", "ko": "가장 흔하게 잘못될 상황은 뭔가요?", "en": "What is the most common way this goes wrong?"},
+        {"id": "dependency_chain", "find": "hidden coupling", "ko": "X가 실패하면 같이 부서지는 게 뭔가요?", "en": "If X fails, what breaks with it?"},
+        {"id": "existing_assets", "find": "duplicate build", "ko": "이미 있는 Y를 확장할까요, 새로 만들까요?", "en": "Extend the existing Y, or build new?"},
+        {"id": "time_horizon", "find": "short-term-fix debt", "ko": "3개월 뒤에도 이 결정이 유효한가요?", "en": "Will this decision still hold in 3 months?"},
+        {"id": "failure_mode", "find": "exception path", "ko": "가장 흔하게 잘못될 상황은 뭔가요?", "en": "What is the most common way this goes wrong?"},
     ],
     "intent": [
-        {"id": "goal_of_goal", "find": "표층 요청 뒤 진짜 목표", "ko": "이게 되면 그다음에 뭘 하실 건가요?", "en": "Once this works, what happens next?"},
-        {"id": "audience", "find": "산출물의 소비자", "ko": "결과물을 누가 보나요/쓰나요?", "en": "Who consumes the output?"},
-        {"id": "rejected_alternatives", "find": "이미 시도한 것", "ko": "이미 해봤는데 안 됐던 방법이 있나요?", "en": "What have you already tried that didn't work?"},
-        {"id": "confidence_level", "find": "사실 vs 추정", "ko": "그건 확인된 사실인가요, 느낌인가요?", "en": "Is that a verified fact or a hunch?"},
+        {"id": "goal_of_goal", "find": "the real goal behind the surface request", "ko": "이게 되면 그다음에 뭘 하실 건가요?", "en": "Once this works, what happens next?"},
+        {"id": "audience", "find": "consumer of the output", "ko": "결과물을 누가 보나요/쓰나요?", "en": "Who consumes the output?"},
+        {"id": "rejected_alternatives", "find": "what's already been tried", "ko": "이미 해봤는데 안 됐던 방법이 있나요?", "en": "What have you already tried that didn't work?"},
+        {"id": "confidence_level", "find": "fact vs. assumption", "ko": "그건 확인된 사실인가요, 느낌인가요?", "en": "Is that a verified fact or a hunch?"},
     ],
     "challenge": [
-        {"id": "premortem", "find": "실패 시나리오", "ko": "6개월 뒤 실패했다고 치죠. 왜였을까요?", "en": "It failed six months from now — why?"},
-        {"id": "inversion", "find": "필수 회피 조건", "ko": "확실히 망치려면 뭘 하면 되나요?", "en": "What would guarantee failure?"},
-        {"id": "stop_criterion", "find": "손절 조건", "ko": "어떤 결과가 나오면 '그만두자'인가요?", "en": "What result would make you stop?"},
-        {"id": "forced_tradeoff", "find": "우선순위", "ko": "속도와 품질이 부딪히면 어느 쪽인가요?", "en": "When speed and quality collide, which wins?"},
+        {"id": "premortem", "find": "failure scenario", "ko": "6개월 뒤 실패했다고 치죠. 왜였을까요?", "en": "It failed six months from now — why?"},
+        {"id": "inversion", "find": "condition that must be avoided", "ko": "확실히 망치려면 뭘 하면 되나요?", "en": "What would guarantee failure?"},
+        {"id": "stop_criterion", "find": "cut-loss condition", "ko": "어떤 결과가 나오면 '그만두자'인가요?", "en": "What result would make you stop?"},
+        {"id": "forced_tradeoff", "find": "priority", "ko": "속도와 품질이 부딪히면 어느 쪽인가요?", "en": "When speed and quality collide, which wins?"},
     ],
 }
 

--- a/agentlas_cloud/mcp_stdio.py
+++ b/agentlas_cloud/mcp_stdio.py
@@ -113,12 +113,15 @@ def _workforce_tool_contracts(*kinds: str) -> dict[str, dict[str, Any]]:
 
 
 def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
-    """검증 도구 전용 selection 스키마 — 순번 지정(candidateOrdinal)을 허용한다.
+    """Selection schema for verification tools only — allows specifying an
+    ordinal (candidateOrdinal) instead of a release ID.
 
-    canonical schemas/workforce-selection.schema.json 은 건드리지 않는다(허브·터미널
-    계약). 이 완화는 MCP 도구 입력에서만 유효하고, 핸들러가 순번을 저장된 명부로
-    정확한 agentReleaseId 로 해석한 뒤 canonical 형태로 심층 검증에 넘긴다.
-    48-hex ID 수기 복사는 실측된 오사 표면이다(2026-07-28 qwen 12회 중 1회 ID 절단).
+    Does not touch the canonical schemas/workforce-selection.schema.json (the
+    Hub/Terminal contract). This relaxation is valid only for MCP tool input;
+    the handler resolves the ordinal against the stored menu into the exact
+    agentReleaseId, then passes the canonical shape on to deep validation.
+    Hand-copying a 48-hex ID is a measured error surface (2026-07-28: 1 of 12
+    qwen attempts truncated the ID).
     """
     schema = _contract_property("selection", description)
     try:
@@ -128,7 +131,7 @@ def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
             "type": "integer",
             "minimum": 1,
             "maximum": 100,
-            "description": "명부에 부여된 후보 순번. agentReleaseId 대신 지정 가능 — 서버가 저장된 세션 명부에서 정확한 릴리스로 해석한다.",
+            "description": "The candidate's ordinal in the menu. May be given instead of agentReleaseId — the server resolves it to the exact release from the stored session menu.",
         }
     except (KeyError, TypeError):
         pass
@@ -137,25 +140,33 @@ def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
 
 _MENU_AUDIT_FIELDS = ("qualificationEvidence", "packageHash", "contentDigest")
 
-# semanticSnapshot 안의 중량 칸. 카드가 문장을 통째로 artifact ID로 슬러그화해 담는
-# 자리라 후보 1명이 수십 개를 싣는데, 후보끼리 겹치지 않아 대조 자체가 불가능하다
-# (라이브 1슬롯 10후보 실측: produces 고유 365개 중 2명 이상 공유 1개=0%, consumes
-# 149개 중 0개). 같은 내용은 summaries가 한 문장으로 이미 갖고 있고, 실제 매칭은
-# Core가 세션 저장소 원본으로 수행한다. 따라서 명부에서는 개수만 남긴다.
+# Heavyweight fields inside semanticSnapshot. This is where a card stuffs a
+# whole sentence slugified into an artifact ID, so a single candidate can
+# carry dozens of them — and since candidates never overlap, comparing them is
+# not even possible in the first place (measured live, 1 slot with 10
+# candidates: 0% of 365 unique `produces` values shared by 2+ candidates, 0 of
+# 149 for `consumes`). The same content is already in the summaries as one
+# sentence, and actual matching is done by Core against the session store's
+# original data. So the menu keeps only the count.
 _MENU_SNAPSHOT_HEAVY_FIELDS = ("produces", "consumes")
 
 
 def _menu_projection(result: dict[str, Any]) -> dict[str, Any]:
-    """검색 응답을 결정용 요약 명부로 투영 — 드롭리스트 방식.
+    """Projects a search response into a decision-ready summary menu — a
+    drop-list approach.
 
-    "남길 것"을 열거하지 않고 감사 중량 필드만 뺀다: 에이전트 속성(카드 스키마)이
-    추가·개명돼도 새 필드는 자동 통과한다. 원본 전문은 Core 세션 저장소가 보유하며
-    검증·준비의 핀 대조는 저장소 원본으로 수행되므로 통제 손실이 없다.
-    실측(1슬롯 10후보): 41,216B → 약 22KB, 판단 실효 정보 손실 0.
+    Instead of enumerating what to keep, it drops only the audit-weight
+    fields: if an agent attribute (card schema) is added or renamed, the new
+    field passes through automatically. Core's session store holds the full
+    original text, and validation/preparation pin-matching is performed
+    against that original data, so no control is lost.
+    Measured (1 slot, 10 candidates): 41,216B -> about 22KB, zero loss of
+    decision-relevant information.
 
-    이 투영은 MCP 표면 전용이다. 터미널 러너는 semanticSnapshot 키 집합을 정확히
-    9개로 단언하므로(agentlas-workforce.cjs assertExactKeys), 같은 접기를 Core
-    공용 경로에 넣으면 그쪽이 candidate_set_invalid로 죽는다.
+    This projection is MCP-surface only. The Terminal runner asserts the
+    semanticSnapshot key set at exactly 9 keys
+    (agentlas-workforce.cjs assertExactKeys), so applying the same folding on
+    Core's shared path would make that side die with candidate_set_invalid.
     """
     projected = {key: value for key, value in result.items() if key != "candidateProvenance"}
     candidate_set = projected.get("candidateSet")
@@ -197,10 +208,11 @@ def _resolve_ordinal_assignments(
     selection: Mapping[str, Any],
     candidate_set: Mapping[str, Any],
 ) -> tuple[dict[str, Any] | None, str | None]:
-    """assignments의 candidateOrdinal을 저장된 명부로 정확한 릴리스 ID로 해석한다.
+    """Resolves each assignment's candidateOrdinal against the stored menu into an exact release ID.
 
-    반환: (canonical 형태로 정규화된 selection, None) 또는 (None, 거절 코드).
-    순번과 릴리스 ID를 동시에 줬는데 서로 다르면 조용히 한쪽을 고르지 않고 거절한다.
+    Returns: (selection normalized to canonical shape, None) or (None, a
+    refusal code). If both an ordinal and a release ID were given and they
+    disagree, this refuses rather than silently picking one.
     """
     slots_by_id: dict[str, list[Mapping[str, Any]]] = {}
     for slot in candidate_set.get("slots", []) or []:
@@ -490,7 +502,7 @@ TOOLS: list[dict[str, Any]] = [
     {
         "name": "hephaestus_cloud_search",
         "description": (
-            "Search ONLY the signed-in user's OWN Agentlas cloud packages (보관함) "
+            "Search ONLY the signed-in user's OWN Agentlas cloud packages "
             "and return a JSON decision with a receipt_id. This is the owner-scoped "
             "leg of the three-scope model: it skips local cards and the public "
             "marketplace, querying the Hub with the owner filter (cargo.*). The "
@@ -517,7 +529,7 @@ TOOLS: list[dict[str, Any]] = [
         "inputSchema": {
             "type": "object",
             "properties": {
-                "request": {"type": "string", "description": "Search request, for example: 시장 리포트 쓸 에이전트 찾아줘."},
+                "request": {"type": "string", "description": "Search request, for example: find an agent that can write a market report."},
                 "project_dir": {"type": "string", "description": "Project directory for context (default: cwd)."},
                 "limit": {"type": "integer", "description": "Candidates per section. Default 10."},
             },
@@ -1773,9 +1785,10 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                     "status": "error",
                     "error": getattr(exc, "code", "workforce_source_search_failed"),
                 }
-            # 기본은 결정용 요약 명부(투영). 원본 전문은 세션 저장소가 보유하므로
-            # 검증·준비의 핀 대조는 손실 없다. 레거시 전량-에코 흐름이 필요한
-            # 호출자만 fullDossier=true 로 원형을 받는다.
+            # Default is the decision-ready summary menu (projection). The
+            # session store holds the full original text, so validation/
+            # preparation pin-matching loses nothing. Only a caller that needs
+            # the legacy full-echo flow gets the original shape via fullDossier=true.
             if arguments.get("fullDossier") is True:
                 return search_result
             return _menu_projection(search_result)
@@ -1828,15 +1841,18 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                 stored_set = federation_result.get("candidateSet")
                 if isinstance(stored_set, Mapping):
                     candidate_set = stored_set
-            # 순번 지정 해석 — 48-hex ID 수기 복사 대신 명부 순번으로 후보를 지정할 수
-            # 있다. 여기서 저장된(또는 제출된) 명부로 정확한 릴리스 ID로 해석해
-            # canonical 형태로 만든 뒤에만 심층 검증에 넘긴다. 해석 실패는 조용한
-            # 대체 없이 거절한다.
+            # Ordinal resolution — lets a candidate be specified by its menu
+            # ordinal instead of hand-copying a 48-hex ID. Resolves it against
+            # the stored (or submitted) menu into the exact release ID, into
+            # canonical shape, and only then passes it on to deep validation.
+            # A resolution failure is refused, with no silent substitute.
             #
-            # prepare에도 같이 건다. validate 전용이던 동안, 순번으로 결재해 accepted를
-            # 받은 호출자가 같은 selection을 prepare에 넘기면 assignments[0].agentReleaseId
-            # 누락 + candidateOrdinal additionalProperties로 거절당했다(실측). validate는
-            # canonical 형태를 돌려주지 않으므로 호출자에게는 되돌릴 방법이 없었다.
+            # This is applied to prepare too. While it was validate-only, a
+            # caller who got an "accepted" verdict by ordinal, then passed the
+            # same selection to prepare, was refused with a missing
+            # assignments[0].agentReleaseId plus a candidateOrdinal
+            # additionalProperties error (measured). validate does not return
+            # the canonical shape, so the caller had no way to recover.
             if (
                 name in ("workforce.validate_selection", "workforce.prepare_execution")
                 and isinstance(selection, Mapping)
@@ -1969,14 +1985,17 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                             "repairable": True,
                             "hubCalls": 0,
                         }
-                    # prepareAttempt의 idempotencyKey는 payload 전체의 canonical
-                    # sha256이라 호스트 LLM이 손으로 만들 수 없는 값이다(터미널
-                    # 러너는 코드로 계산한다). MCP 호스트 경로에서는 미제공 시
-                    # Core가 같은 재료 — 정확한 WorkOrder/해석된 Selection의
-                    # canonical digest, federatedSelection의 수령 digest·소스 핀 —
-                    # 로 파생한다. occurrenceId를 selectionSessionId에서 파생하므로
-                    # 같은 세션의 재시도는 같은 키로 떨어져 멱등성이 유지된다.
-                    # 제공된 prepareAttempt는 그대로 대조 검증한다(약화 없음).
+                    # prepareAttempt's idempotencyKey is the canonical sha256
+                    # of the entire payload — a value a host LLM cannot
+                    # compute by hand (the Terminal runner computes it in
+                    # code). On the MCP host path, when it's not supplied,
+                    # Core derives it from the same material — the exact
+                    # WorkOrder / resolved Selection's canonical digest, plus
+                    # federatedSelection's received digest and source pins.
+                    # occurrenceId is derived from selectionSessionId, so a
+                    # retry within the same session lands on the same key and
+                    # idempotency is preserved. A supplied prepareAttempt is
+                    # matched and validated as-is (no weakening).
                     prepare_attempt = arguments.get("prepareAttempt")
                     if prepare_attempt is None:
                         from .workforce.prepare_cache import prepare_attempt_payload
@@ -2000,8 +2019,9 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                                     ],
                                 )
                             except Exception:
-                                # 파생 실패는 조용한 대체 없이 기존 필수-인자
-                                # 검증 경로가 정직하게 거절하도록 남겨 둔다.
+                                # A derivation failure is left for the
+                                # existing required-argument validation path
+                                # to refuse honestly, with no silent substitute.
                                 prepare_attempt = None
                     service = WorkforceSourceService(session_store=store)
                     source_bundles = service.fetch_selected_runtime_bundles(
@@ -2162,7 +2182,7 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         return with_bootstrap(decision)
     if name == "hephaestus_cloud_search":
         # Owner-scoped: scope="cloud" implies hub_only inside route_request and
-        # queries only the signed-in user's OWN cloud packages (보관함).
+        # queries only the signed-in user's OWN cloud packages.
         # This routes, so it owes the same Work Brief contract as
         # hephaestus_route / `route --scope cloud`: same project_dir, same
         # brief, same reason on the way back when the brief cannot be used.

--- a/agentlas_cloud/memory_contract.py
+++ b/agentlas_cloud/memory_contract.py
@@ -2,7 +2,7 @@
 memory rework, so the three surfaces (Desktop TS, Terminal CJS, hep Python) do
 not silently drift.
 
-Background: the memory logic lives in three places (CLAUDE.md "3제품 싱크" pattern,
+Background: the memory logic lives in three places (CLAUDE.md "3-product sync" pattern,
 extended here to the memory contract). The hep plugin is a lighter, per-slug
 implementation, but the *contracts* it produces on disk — the
 ``.agentlas/evolution-proposals.json`` shape, the ``context_source`` marker

--- a/agentlas_cloud/memory_hook.py
+++ b/agentlas_cloud/memory_hook.py
@@ -212,10 +212,12 @@ def _source_path(item: dict[str, Any]) -> Path | None:
 def _source_staleness(item: dict[str, Any]) -> tuple[str | None, str | None]:
     """(inline age tag, staleness directive) for one cited source document.
 
-    2026-07-29 사고: 인덱스 문서가 12일 전에 동결됐는데 캡슐이 그 사실을 어디에도
-    표기하지 않아, 세션이 7/17 시점 사실을 현재로 단정했다. 나이는 캡슐 소비자가
-    추론할 수 없는 정보이므로 반드시 생산자가 라벨로 실어야 한다. Fail-open:
-    판별 불가능한 소스는 조용히 무표기(경고 오발보다 낫다).
+    2026-07-29 incident: the index document had been frozen for 12 days, but
+    the capsule carried no signal of that anywhere, so a session asserted
+    facts from 7/17 as current. Age is not something a capsule consumer can
+    infer, so the producer must always attach it as a label. Fail-open: a
+    source whose age can't be determined stays silently unlabeled rather than
+    risking a false staleness warning.
     """
 
     path = _source_path(item)
@@ -429,10 +431,12 @@ def build_capsule(
     if not lines and not evolution_line and not workforce_lines and not context_slice_line:
         return None, binding_root
     adapter_name, retrieval_status = _adapter_status(agent_result or project_result)
-    # 방출 계약: 판단은 세션 LLM이, 전달은 시스템이. .agentlas/pm은 이 백스톱
-    # 인덱스와 Desktop 인덱스가 모두 임베드하는 folder-shared 층이라, 여기 적힌
-    # 학습은 다음 세션부터 모든 호스트·제품의 recall로 돌아온다 (2026-07-29
-    # 실측: 실작업 학습이 이 층 밖에만 쌓여 소울·큐레이터가 굶었다).
+    # Emission contract: judgment is the session LLM's job, delivery is the
+    # system's. .agentlas/pm is a folder-shared layer that both this backstop
+    # index and the Desktop index embed, so a learning written here flows back
+    # into recall for every host and product starting the next session
+    # (measured 2026-07-29: real task learnings that only piled up outside
+    # this layer starved the Soul and Curator).
     emit_line = (
         "emit=after substantial work, record durable project learnings "
         "(fact/decision/procedure WITH evidence; never secrets or transcripts) as markdown in "

--- a/agentlas_cloud/model_allocation.py
+++ b/agentlas_cloud/model_allocation.py
@@ -17,12 +17,15 @@ from typing import Any, Mapping
 
 SCHEMA_VERSION = "agentlas.model-allocation-decision.v1"
 TIERS = ("economy", "balanced", "frontier")
-# 알려진 값은 정책 상한과 비교할 "랭크 폴백"으로만 쓴다 — "유효한가" 게이트로 쓰지 않는다.
-# 2026-07-28 라이브 실측: codex debug models가 gpt-5.6-sol에서 "ultra"(자동 위임) 리즌
-# 레벨을 실제로 광고했다. 이 튜플로 게이트를 걸면 provider가 이미 출시한 값을 우리가
-# 스키마 검증 단계에서 조용히 거절한다(전체 decision이 invalid_effort로 폐기됨). 새 값이
-# 나올 때마다 이 튜플을 고치는 대신, 세션 인벤토리가 보고하는 모델 자체 순서(=능력 랭크,
-# provider 계약)를 신뢰하는 쪽으로 옮겼다 — 아래 normalize_effort/_bounded_effort 참고.
+# The known values are used only as a "rank fallback" to compare against a
+# policy ceiling — never as a validity gate. Measured live 2026-07-28: codex
+# debug models actually advertised an "ultra" (auto-delegate) reason level on
+# gpt-5.6-sol. Gating on this tuple would have us silently reject a value the
+# provider already shipped, at the schema-validation step (discarding the
+# whole decision as invalid_effort). Instead of patching this tuple every time
+# a new value appears, validation moved to trusting the model's own ordering
+# as reported by the session inventory (= capability rank, a provider
+# contract) — see normalize_effort/_bounded_effort below.
 EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 EFFORT_TOKEN_RE = re.compile(r"^[a-z][a-z0-9-]{0,23}$")
 PHASES = ("plan", "execute", "verify", "synthesize", "route", "clarify")
@@ -48,7 +51,7 @@ INVOCATION_STAGE_PHASES = {
     "clarify": "clarify",
 }
 TIER_RANK = {tier: index for index, tier in enumerate(TIERS)}
-# 알려진 값의 폴백 랭크만 — 미지의 값을 이 표로 거절하지 않는다(_bounded_effort 참고).
+# Fallback rank for known values only — an unknown value is never rejected by this table (see _bounded_effort).
 EFFORT_RANK = {effort: index for index, effort in enumerate(EFFORTS)}
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@-]{2,255}$")
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -126,9 +129,11 @@ def normalize_tier(value: Any) -> str | None:
 
 
 def normalize_effort(value: Any) -> str | None:
-    # 신택스만 검증한다 — 화이트리스트 존재는 게이트로 쓰지 않는다(위 EFFORTS 주석).
-    # 이 함수는 parent-AI가 요청한 값과, 세션 인벤토리가 보고한 모델 자체 지원 목록
-    # 양쪽에 다 쓰인다 — 열어두면 두 경로 모두에서 새 값이 조용히 안 드롭된다.
+    # Validates syntax only — the existence of a whitelist is not used as a
+    # gate (see the EFFORTS comment above). This function is used both for a
+    # value the parent AI requested and for the model's own supported-value
+    # list as reported by the session inventory — keeping it open means a new
+    # value never gets silently dropped on either path.
     normalized = _text(value).lower()
     return normalized if EFFORT_TOKEN_RE.fullmatch(normalized) else None
 
@@ -460,9 +465,10 @@ def _bounded_effort(requested: str, supported: list[str], max_effort: str) -> tu
     if eligible:
         resolved = max(eligible, key=lambda item: _effort_rank(item, supported))
     else:
-        # 요청/상한 어느 쪽과도 동시에 맞는 값이 없다 — 모델이 제공하는 가장 낮은
-        # 값으로 최대한 보수적으로 내려간다(원래 폴백과 동일, 상한을 우선시해
-        # 요청보다 위로 에스컬레이션하지 않는다).
+        # Nothing matches both the request and the ceiling at once — fall
+        # back as conservatively as possible, to the lowest value the model
+        # offers (same as the original fallback; the ceiling takes priority,
+        # so this never escalates above what was requested).
         resolved = min(supported, key=lambda item: _effort_rank(item, supported))
     return resolved, resolved != requested
 
@@ -523,12 +529,15 @@ def resolve_model_allocation(
     inventory = _normalize_inventory(raw_inventory)
     policy = dict(policy or {})
     escalation_request, escalation_issues = _validate_escalation(escalation)
-    # maxEscalations는 부모가 선언한 비용 상한이다. 상한은 "권한을 주는 값"이 아니라
-    # "권한을 제한하는 값"이므로, 관계없는 검증 이슈(unknown_fields 등)가 하나만 섞여도
-    # 상한 검사를 통째로 건너뛰면 안 된다. 예전에는 `and not issues` 때문에 무관한
-    # 필드 하나가 상한을 무력화해 maxEscalations=0인 결정도 frontier/xhigh로 승격됐다.
-    # decision이 존재하면 selection.maxEscalations는 항상 정규화되어 있고(불량/누락은
-    # 기본값 0) 따라서 이슈가 있는 결정일수록 더 보수적으로 막힌다 — fail-closed.
+    # maxEscalations is a cost ceiling the parent declared. A ceiling is a
+    # value that restricts authority, not one that grants it, so a single
+    # unrelated validation issue (unknown_fields, etc.) mixed in must never
+    # skip the ceiling check entirely. Previously, `and not issues` let one
+    # irrelevant field disable the ceiling, so even a maxEscalations=0
+    # decision could be escalated to frontier/xhigh. Whenever a decision
+    # exists, selection.maxEscalations is always normalized (a bad or missing
+    # value defaults to 0), so a decision with issues is blocked more
+    # conservatively, not less — fail-closed.
     if (
         escalation_request is not None
         and decision is not None
@@ -554,8 +563,9 @@ def resolve_model_allocation(
         or "orchestrator"
     )
     if escalation_request is not None:
-        # 승격은 단계→역할 기본 매핑에 대한 유일한 허용 예외다. worker 단계의
-        # 마지막 재시도 한 번만 orchestrator 역할 정책으로 해석한다.
+        # Escalation is the one allowed exception to the default stage->role
+        # mapping. Only the last retry of a worker stage is interpreted under
+        # the orchestrator role policy.
         resolved_role = "orchestrator"
     role_policy, inherited_role_policy = _policy_for_role(policy, resolved_role)
     current_model_id = _text(role_policy.get("currentModelId"))
@@ -613,8 +623,9 @@ def resolve_model_allocation(
         else:
             reasons.append("pinned_model_unavailable_or_incompatible")
 
-    # 승격된 재시도는 worker 단계용 parent decision이 아니라 orchestrator 역할
-    # 정책이 지배한다 — decision은 맥락으로만 남고 모델 선택에는 쓰지 않는다.
+    # An escalated retry is governed by the orchestrator role policy, not the
+    # worker stage's parent decision — the decision stays only as context and
+    # is not used for model selection.
     if selected is None and decision is not None and not issues and escalation_request is None:
         requested_tier = decision["selection"]["tier"]
         if TIER_RANK[requested_tier] > TIER_RANK[max_tier]:
@@ -666,14 +677,17 @@ def resolve_model_allocation(
                 reasons.append("parent_exact_model_required_for_ambiguous_inventory")
 
     if selected is None and escalation_request is not None:
-        # 승격 재시도는 위 블록에서 parent decision을 의도적으로 건너뛴다. 그래서
-        # 운영자 핀(pinnedModelId)이 없으면 여기까지 어떤 분기도 selected를 채우지
-        # 못했고, 유일하게 허용된 재시도가 항상 unresolved로 죽었다 — 핀은 선택
-        # 사항이므로 핀을 두지 않은 모든 운영자에게 승격 계약 자체가 사문화된다.
-        # 핀이 없을 때도 orchestrator 역할 정책만으로 결정적으로 고른다: maxTier
-        # 이하 후보 중 최상위 tier를 쓰고("약모델 실패 → 강모델 승격"), 동률이면
-        # 역할의 현재 모델로 가른다. 정책 상한을 넘기지 않으므로 승격이 비용
-        # 가드레일을 뚫는 경로가 되지는 않는다.
+        # An escalation retry deliberately skips the parent decision in the
+        # block above. So without an operator pin (pinnedModelId), no branch
+        # up to this point had filled `selected`, and the one allowed retry
+        # always died as unresolved — since a pin is optional, this silently
+        # voided the escalation contract for every operator who didn't set
+        # one. Even with no pin, choose deterministically from the
+        # orchestrator role policy alone: use the highest tier among
+        # candidates at or below maxTier ("weak model failed -> escalate to a
+        # strong one"), breaking ties with the role's current model. This
+        # never exceeds the policy ceiling, so escalation is never a path
+        # around the cost guardrail.
         allowed = [
             item
             for item in compatible_inventory
@@ -702,9 +716,10 @@ def resolve_model_allocation(
         if decision is None or issues:
             reasons.append("parent_decision_missing_or_invalid")
         elif escalation_request is not None:
-            # 승격 경로는 parent decision의 모델을 요청하지 않는다. 여기서
-            # no_compatible_requested_model을 남기면 살아 있는 호환 모델을 두고도
-            # "요청 모델이 비호환"이라는 거짓 사유를 보고하게 된다.
+            # The escalation path never requests the parent decision's model.
+            # Recording no_compatible_requested_model here would report a
+            # false "the requested model is incompatible" reason even though
+            # a compatible model was actually available.
             reasons.append("escalation_target_unavailable")
         else:
             reasons.append("no_compatible_requested_model")
@@ -719,8 +734,10 @@ def resolve_model_allocation(
     risk = decision["features"]["risk"] if decision else "unknown"
     parent_reason_codes = list(decision["reasonCodes"]) if decision else []
     if escalation_request is None and "escalated-after-failure" in parent_reason_codes:
-        # 승격 없이 승격 사유코드만 오는 것은 계약 위반이다 — 조용히 통과시키면
-        # 소비자가 승격 필드 없는 승격을 믿게 된다. 사유코드를 떼고 이슈로 남긴다.
+        # An escalation reason code arriving with no actual escalation is a
+        # contract violation — passing it through silently would let a
+        # consumer believe an escalation happened with no escalation field.
+        # Strip the reason code and record it as an issue instead.
         escalation_issues.append("escalation_reason_code_without_escalation")
         parent_reason_codes = [code for code in parent_reason_codes if code != "escalated-after-failure"]
     if escalation_request is not None:

--- a/agentlas_cloud/networking/card_lint.py
+++ b/agentlas_cloud/networking/card_lint.py
@@ -196,7 +196,7 @@ def lint_card(card: dict[str, Any]) -> dict[str, Any]:
     if bench_cases < 10:
         ready_blockers.append(f"needs >=10 benchmark cases (has {bench_cases})")
 
-    # 이력서(workforce) block — the hub standard résumé the Workforce search
+    # résumé (workforce) block — the hub standard résumé the Workforce search
     # matches on. Measured over the live catalog (2026-07-27) sellers declared
     # roles/modalities on 0 of 250 cards, so every WorkOrder using those fields
     # excluded the whole catalog. Built packages must ship the block filled;
@@ -205,9 +205,11 @@ def lint_card(card: dict[str, Any]) -> dict[str, Any]:
     # ontology snapshot supplies aliases/relations, not a profession allowlist.
     workforce = card.get("workforce")
     if not isinstance(workforce, dict):
-        # 자동 빌드 파이프라인(스톰 워커, 변환 패키징)은 블록을 손으로 못 쓴다 —
-        # 결정적 파생이 가능하므로 린트는 경고만 남기고, 하드 게이트는 서버
-        # 등록 경계(workforce_resume_incomplete)와 업로드 관문의 자동 채움이 맡는다.
+        # An automated build pipeline (Stormbreaker workers, conversion
+        # packaging) cannot hand-write this block. Since a deterministic
+        # derivation is possible, lint only warns — the hard gate is left to
+        # the server registration boundary (workforce_resume_incomplete) and
+        # the upload gate's auto-fill.
         derived = ensure_workforce_block(dict(card))
         workforce = derived["workforce"]
         warnings.append(

--- a/agentlas_cloud/networking/card_store.py
+++ b/agentlas_cloud/networking/card_store.py
@@ -44,8 +44,9 @@ def save_card(home: Path, card: dict[str, Any]) -> Path:
     card["updated_at"] = card.get("updated_at") or utc_now()
     target = card_path(home, card)
     atomic_write_json(target, card)
-    # 데스크탑 핸드오프 — trusted local 등록은 수동 임포트 없이 Agentlas Desktop
-    # 라이브러리에 도달해야 한다(자격 미달/실패는 조용히 무시, 등록을 깨지 않음).
+    # Desktop handoff — a trusted local registration must reach the Agentlas
+    # Desktop library without a manual import (a failure or unmet requirement
+    # is silently ignored here rather than breaking the registration).
     enqueue_desktop_sync(home, card)
     return target
 

--- a/agentlas_cloud/networking/desktop_sync.py
+++ b/agentlas_cloud/networking/desktop_sync.py
@@ -29,7 +29,8 @@ from .bootstrap import atomic_write_json, read_json, utc_now
 PENDING_DIR = "desktop-sync/pending"
 DONE_DIR = "desktop-sync/done"
 
-# 패키지 실체 확인용 마커 — 이 중 하나는 있어야 임포트 가능한 폴더로 본다.
+# Markers that confirm a real package — a folder must have at least one of
+# these to be treated as importable.
 _PACKAGE_MARKERS = ("agentlas.json", "AGENT.md", "AGENTS.md", "TEAM.md", "CLAUDE.md")
 
 
@@ -45,7 +46,8 @@ def _package_ref(card: dict[str, Any]) -> Path | None:
     if not raw:
         return None
     ref = Path(raw)
-    # reindex가 상대경로('.')를 남긴 이력이 있다 — 절대경로 + 실존 + 패키지 마커까지 요구.
+    # reindex has a history of leaving a relative path ('.') behind — require
+    # an absolute path, that it actually exists, and a package marker too.
     if not ref.is_absolute() or not ref.is_dir():
         return None
     if not any((ref / marker).is_file() for marker in _PACKAGE_MARKERS):

--- a/agentlas_cloud/networking/goal_loop.py
+++ b/agentlas_cloud/networking/goal_loop.py
@@ -9,13 +9,13 @@ repetition is the point, not a defect.
 This module adds the missing half: a controller that auto-constructs a loop for a
 task and drives it **until the goal verifies**, while staying stable —
 
-- **don't break (안 끊기게):** a transient iteration failure does not kill the loop.
+- **don't break:** a transient iteration failure does not kill the loop.
   It is journaled and retried with backoff, up to `max_consecutive_failures` in a
   row. Only a genuine streak of hard failures stops the run.
 - **don't run away:** a hard `max_iterations` ceiling, plus stall detection —
   if `stall_window` consecutive iterations make no new progress, the loop stops as
   `stalled` instead of spinning forever. Progress is measured, not assumed.
-- **keep the goal until done (될때까지 목표 유지):** the loop only reports
+- **keep the goal until done:** the loop only reports
   `reached_goal` when the goal predicate verifies; it never claims success on a
   bare "it ran."
 - **survive a hard stop:** every iteration is a Run Journal step, so a killed loop

--- a/agentlas_cloud/networking/router.py
+++ b/agentlas_cloud/networking/router.py
@@ -636,14 +636,17 @@ def _hub_query_has_fitting_borrowable(query_tokens: list[str], results: list[dic
     )
 
 
-# 일반적인 빌드/기획 동사는 "이 에이전트를 지목했다"고 볼 만큼 특이하지 않으므로 제외 —
-# 진짜 역할 단어("웹마스터", "카피라이터")로만 매칭한다.
+# Generic build/planning verbs are excluded — they aren't distinctive enough
+# to count as "this agent was explicitly named." Only real role words
+# ("webmaster", "copywriter") count as a match.
 _GENERIC_ROLE_TOKENS = {
     "기획", "제작", "개발", "구현", "빌드", "만들", "작업", "불러", "불러서", "해줘", "해",
     "팀", "웹", "앱", "사이트", "페이지", "랜딩", "랜딩페이지", "에이전트", "등",
     "agent", "team", "build", "make", "plan", "create", "page", "landing", "web", "app", "site",
-    # 제품/브랜드 주제어 — 요청의 '주제'이지 에이전트 '지목'이 아니다. 이게 없으면 "Agentlas에
-    # 대해서 글 써줘"에서 이름에 agentlas가 든 후보(PRD 메이커 등)를 "지목됨"으로 오판해 다 빌려온다.
+    # Product/brand topic words — these are the request's "topic," not an
+    # agent being "named." Without this, "write something about Agentlas"
+    # would misjudge any candidate with "agentlas" in its name (a PRD maker,
+    # etc.) as "named" and borrow all of them.
     "agentlas", "hephaestus", "oberon", "대해서", "대한", "관련",
 }
 
@@ -719,9 +722,11 @@ def _byom_execution_plan(
                 )
     else:
         borrowable = [item for item in (results or []) if _is_borrowable(item)]
-        # 사용자가 에이전트를 명시적으로 지목했으면("웹마스터 카피라이터 불러서") 전부 빌려온다 —
-        # 다중 역할 요청을 최상위 후보 1개로 축소하지 않는다(Hub가 오프도메인 에이전트를 명시된
-        # 에이전트보다 높게 랭크할 수 있으므로 명시 지목을 우선).
+        # If the user explicitly named agents (e.g. "call the webmaster and
+        # the copywriter"), borrow all of them — a multi-role request is never
+        # reduced to a single top candidate (the Hub can rank an off-domain
+        # agent above one that was explicitly named, so an explicit name
+        # takes priority).
         named = _explicitly_named_borrowables(query, borrowable)
         if named:
             for cand in named[:5]:
@@ -741,10 +746,12 @@ def _byom_execution_plan(
     # returning a task_force with execution=null.
     if not recommended and not stages:
         return None
-    # 명시 지목이 2개+면 이건 "여러 전문가가 협업하는 하나의 산출물" — 실행 모델이 임시
-    # 오케스트레이터 역할(plan→dispatch→synthesize)을 맡도록 directive를 전환한다. CLI에는
-    # 별도 오케스트레이터 세션이 없으므로(hep-storm --executor-command 없이는) 베이스 모델이
-    # 매니저가 되는 게 현실적 경로다.
+    # Two or more explicit names means this is "one deliverable from several
+    # specialists collaborating" — switch the directive so the execution
+    # model takes on a temporary orchestrator role (plan -> dispatch ->
+    # synthesize). The CLI has no separate orchestrator session (short of
+    # hep-storm --executor-command), so the base model becoming the manager
+    # is the realistic path.
     core_stages = [
         str(stage.get("stage"))
         for stage in (stages or [])
@@ -792,7 +799,7 @@ def _byom_execution_plan(
         )
     return {
         "mode": "byom_local_grounded",
-        # 다중 명시 지목이면 실행 모델이 매니저 역할을 맡는다는 신호.
+        # Multiple explicit names is the signal for the execution model to take on the manager role.
         "formation": "temporary_orchestrator" if multi else "single_specialist",
         "primary_agent": primary,
         "recommended_agents": recommended,
@@ -993,7 +1000,7 @@ def route_request(
 
     # Three-scope command model (docs/hephaestus-network-2.0.md):
     #   scope="cloud"   -> /hep-cloud: search ONLY the signed-in user's
-    #                     OWN cloud packages (보관함). Owner-scoped Hub query,
+    #                     OWN cloud packages. Owner-scoped Hub query,
     #                     implies hub_only (skip local + public marketplace).
     #   scope="network" -> /hep-network: search Cloud > Bookmark > public Hub
     #                     in that order. Used with hub_only by the network command.
@@ -1164,7 +1171,7 @@ def route_request(
         )
 
     if hub_only:
-        # The owner cloud (보관함) and the public marketplace share this
+        # The owner cloud and the public marketplace share this
         # Hub-only flow; the only difference is the scope passed to the Hub and
         # the receipt/reason tag, so /hep-cloud and /hep-network
         # stay one code path with two scopes.

--- a/agentlas_cloud/networking/router_agent_call.py
+++ b/agentlas_cloud/networking/router_agent_call.py
@@ -53,9 +53,11 @@ def router_escalation(
         return None
     action = str(result.get("action") or "")
     hub_results = ((result.get("hub") or {}).get("results")) if isinstance(result.get("hub"), dict) else None
-    # hub_candidates 는 "후보를 찾았다"는 이유로 렉시컬 top-1 을 그대로 primary 로 밀지만,
-    # 렉시컬 점수는 브랜드/주제어에 쉽게 휘둘려 오선택한다("쓰레드 글 써줘"→PRD 메이커). 후보가 2개 이상이면
-    # 호스트 LLM 라우터에 넘겨 '의도 적합도'로 재정렬하게 한다(키워드 나열이 아니라 의미 기반 선택).
+    # hub_candidates pushes the lexical top-1 straight through as primary just
+    # because "a candidate was found," but a lexical score is easily thrown off
+    # by a brand name or topic word and mis-selects (e.g. "write a Threads
+    # post" -> a PRD maker). With two or more candidates, hand off to the host
+    # LLM router to re-rank by actual intent fit instead of keyword overlap.
     hub_multi = (
         action == "hub_candidates"
         and isinstance(hub_results, list)

--- a/agentlas_cloud/package_contract.py
+++ b/agentlas_cloud/package_contract.py
@@ -371,7 +371,7 @@ def _verify_artifact(workspace: Path, artifact: dict[str, Any], base: Path) -> d
             source["ref"] = str(workspace)
         try:
             lint = lint_card({**doc, "source": source})
-        except Exception as err:  # 카드가 어떤 모양이든 게이트는 크래시하지 않는다
+        except Exception as err:  # the gate must not crash no matter what shape the card is
             lint = {"errors": [f"lint crashed on malformed card: {err}"], "ready_blockers": []}
         report["routing_lint"] = lint
         problems.extend(f"routing-card: {err}" for err in lint.get("errors", []))

--- a/agentlas_cloud/project_bootstrap.py
+++ b/agentlas_cloud/project_bootstrap.py
@@ -1358,10 +1358,12 @@ def _bounded_project_map(project_map: dict[str, Any]) -> tuple[str, int]:
             key=lambda key: (-int(ref_counts.get(key) or 0), key),
         )
         original_refs = len(ordered)
-        # 바이트 예산이 계약이고 "최소 1,000개 유지"는 휴리스틱이다. 파일당 심볼
-        # 상한을 올린 뒤로는 이 바닥이 작은 예산과 교착해 맵 전체를 잃게 했다
-        # (예산 초과 = OSError = 맵 없음). ordered는 참조 빈도순이므로 바닥을
-        # 1로 내려도 가장 뜨거운 심볼부터 예산이 허락하는 만큼 남는다.
+        # The byte budget is the contract; "keep at least 1,000" is only a
+        # heuristic. Since the per-file symbol cap was raised, that floor has
+        # deadlocked against a small budget and lost the whole map (budget
+        # exceeded = OSError = no map). ordered is sorted by reference
+        # frequency, so lowering the floor to 1 still keeps as many of the
+        # hottest symbols as the budget allows.
         while len(raw.encode("utf-8")) > MAX_CODE_MAP_BYTES and len(ordered) > 1:
             ordered = ordered[: max(1, len(ordered) // 2)]
             allowed = set(ordered)
@@ -1374,9 +1376,10 @@ def _bounded_project_map(project_map: dict[str, Any]) -> tuple[str, int]:
             project_map["stats"]["outputTruncated"] = True
             project_map["stats"]["refIndexSymbolsOmitted"] = original_refs - len(allowed)
             raw = json.dumps(project_map, ensure_ascii=False, separators=(",", ":")) + "\n"
-    # 파일당 심볼 상한을 올린 뒤로는 defIndex/topSymbols 단독으로도 작은 예산을
-    # 넘을 수 있다. 사다리 뒤쪽에 두어 정의 색인이 가장 오래 살아남게 하되,
-    # 바이트 예산이 최종 계약이므로 여기서도 수렴할 때까지 절반씩 줄인다.
+    # Since the per-file symbol cap was raised, defIndex/topSymbols alone can
+    # now exceed a small budget too. This step comes last in the ladder so the
+    # definition index survives longest, but the byte budget is still the
+    # final contract, so keep halving until it converges here too.
     if len(raw.encode("utf-8")) > MAX_CODE_MAP_BYTES and isinstance(project_map.get("defIndex"), dict) and project_map["defIndex"]:
         def_counts = project_map.get("refCount") if isinstance(project_map.get("refCount"), dict) else {}
         ordered_defs = sorted(

--- a/agentlas_cloud/project_index_backstop.py
+++ b/agentlas_cloud/project_index_backstop.py
@@ -156,9 +156,11 @@ def _read_bounded_text(path: Path, max_bytes: int) -> str | None:
 def _discover_pm_files(project_root: Path) -> list[tuple[str, str]]:
     """Bounded pm documents, session learnings first and newest first.
 
-    2026-07-29 실측: 이름순·루트우선 순회에서는 7월 중순의 대형 HANDOFF 문서가
-    48K자 예산을 먼저 소진해, 방금 기록한 `learnings/` 학습이 인덱스에 한 글자도
-    못 실렸다. recall 가치는 최신·학습 문서가 가장 크므로 그 순서로 예산을 쓴다.
+    Measured 2026-07-29: a name-ordered, root-first traversal let a large
+    mid-July HANDOFF document exhaust the 48K-character budget first, so a
+    learning recorded moments earlier never made it into the index at all.
+    Recall value is highest for the newest and the learnings documents, so
+    the budget is spent in that order.
     """
 
     pm_root = project_root / ".agentlas" / PM_DIR

--- a/agentlas_cloud/research/adapters/agentlas_browser_launcher.mjs
+++ b/agentlas_cloud/research/adapters/agentlas_browser_launcher.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-// Agentlas Browser (CDP) — 범용 엔진. 실제 로그인 Chrome 전용 프로필을 원격 디버깅 포트로 띄우고
-// @playwright/mcp 를 CDP 로 붙여 MCP 브라우저 도구를 제공한다. 이 프로세스가 client ↔ @playwright/mcp
-// 사이를 stdio 로 프록시하며 (1) 되돌릴 수 없는 행동 승인 게이트, (2) learn-and-replay 스킬 레이어를 얹는다.
-// 의존성 0(순수 node). 개인 데이터는 로컬에서만 사용, 어디로도 전송하지 않는다.
+// Agentlas Browser (CDP) — general-purpose engine. Launches the real, already
+// logged-in Chrome profile with a remote debugging port, then attaches
+// @playwright/mcp over CDP to provide MCP browser tools. This process proxies
+// stdio between the client and @playwright/mcp, layering on (1) an approval
+// gate for irreversible actions, and (2) a learn-and-replay skill layer.
+// Zero dependencies (pure node). Personal data is used locally only and never sent anywhere.
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -86,7 +88,7 @@ async function ensureChrome() {
   throw new Error('Chrome CDP port did not open: ' + PORT);
 }
 
-// ── 승인 게이트 ──────────────────────────────────────────────────
+// ── approval gate ──────────────────────────────────────────────────
 // CONTRACT (fail-closed): the regexes below only LABEL the approval kind —
 // they never make the final "no gate needed" decision for a commit-like
 // action. A click/keypress/upload that submits, pays, sends, or deletes but
@@ -146,8 +148,8 @@ function requestApproval(site, actionType, summary) {
   });
 }
 
-// ── learn-and-replay 스킬 레이어 ─────────────────────────────────
-// 재생/기록 대상 액션 툴(읽기 전용 snapshot/screenshot 등은 제외).
+// ── learn-and-replay skill layer ─────────────────────────────────
+// Action tools eligible for recording/replay (excludes read-only ones like snapshot/screenshot).
 const RECORDABLE = new Set(['browser_navigate', 'browser_navigate_back', 'browser_click', 'browser_type', 'browser_fill', 'browser_fill_form', 'browser_select_option', 'browser_press_key', 'browser_hover', 'browser_file_upload', 'browser_drag']);
 const SKILL_TOOLS = [
   { name: 'browser_skill_list', description: 'List saved Agentlas browser skills (learned action sequences).', inputSchema: { type: 'object', properties: {} } },
@@ -171,15 +173,15 @@ async function main() {
   child.on('error', (e) => { log('failed to start @playwright/mcp', String(e)); process.exit(1); });
   child.on('exit', (code) => process.exit(code == null ? 0 : code));
 
-  const recording = [];            // 이 세션에서 성공한 액션 시퀀스
-  const pending = new Map();       // client 원본 tools/call: id -> {name, args}
-  const waiters = new Map();       // 내부(replay) tools/call: id -> resolve
+  const recording = [];            // sequence of actions that succeeded in this session
+  const pending = new Map();       // client's original tools/call: id -> {name, args}
+  const waiters = new Map();       // internal (replay) tools/call: id -> resolve
   let currentUrl = '';
   let internalSeq = 0;
   const writeClient = (obj) => { try { process.stdout.write(JSON.stringify(obj) + '\n'); } catch (e) {} };
   const forwardRaw = (line) => { try { child.stdin.write(line + '\n'); } catch (e) {} };
 
-  // 승인 게이트 통과 여부 판정(공유). 통과=null, 거부=사유문자열.
+  // Shared approval-gate verdict. Pass = null, refuse = reason string.
   const gate = async (name, args, preJudgedKind) => {
     const actionType = classifyAction(name, args, preJudgedKind);
     if (!actionType) return null;
@@ -191,7 +193,7 @@ async function main() {
     return decision === 'approved' ? null : actionType;
   };
 
-  // 내부에서 child 에 tools/call 을 보내고 응답을 받는다(replay 용).
+  // Internally sends a tools/call to the child and gets the response (for replay).
   const callChild = (name, args) => new Promise((resolve) => {
     const id = 'agx-' + (++internalSeq);
     waiters.set(id, resolve);
@@ -214,14 +216,14 @@ async function main() {
     writeClient({ jsonrpc: '2.0', id: replyId, result: { content: [{ type: 'text', text: 'Replayed skill "' + name + '" (' + (skill.steps || []).length + ' steps):\n' + results.join('\n') }] } });
   };
 
-  // client → child 방향
+  // client -> child direction
   const handleClientLine = (line) => {
     if (!line.trim()) { forwardRaw(line); return; }
     let msg; try { msg = JSON.parse(line); } catch (e) { forwardRaw(line); return; }
     if (msg && msg.method === 'tools/call' && msg.params) {
       const name = msg.params.name || '';
       const args = msg.params.arguments || {};
-      // 스킬 툴은 로컬 처리(child 로 안 보냄).
+      // Skill tools are handled locally (not sent to the child).
       if (name === 'browser_skill_list') { writeClient({ jsonrpc: '2.0', id: msg.id, result: { content: [{ type: 'text', text: JSON.stringify(listSkills()) }] } }); return; }
       if (name === 'browser_skill_save') {
         try { const doc = saveSkill(args.name, recording.slice(), args.description); writeClient({ jsonrpc: '2.0', id: msg.id, result: { content: [{ type: 'text', text: 'Saved skill "' + doc.name + '" with ' + doc.steps.length + ' steps → ' + skillPath(doc.name) }] } }); }
@@ -229,7 +231,7 @@ async function main() {
         return;
       }
       if (name === 'browser_skill_replay') { doReplay(args.name, msg.id); return; }
-      // 일반 액션: 승인 게이트 + 기록. 부모가 _meta 로 사전판정을 보냈으면 그 판정이 우선.
+      // Ordinary action: approval gate + record. If the parent sent a pre-judged verdict via _meta, that verdict wins.
       if (name === 'browser_navigate' && args.url) currentUrl = String(args.url);
       const preJudgedKind = (msg.params._meta || {})['agentlas/actionKind'];
       const actionType = classifyAction(name, args, preJudgedKind);
@@ -246,19 +248,19 @@ async function main() {
     forwardRaw(line);
   };
 
-  // child → client 방향 (응답 가로채기: replay waiter / 기록 / tools/list 주입)
+  // child -> client direction (intercepts responses: replay waiter / recording / tools/list injection)
   const handleChildLine = (line) => {
     if (!line.trim()) { process.stdout.write(line + '\n'); return; }
     let msg; try { msg = JSON.parse(line); } catch (e) { process.stdout.write(line + '\n'); return; }
-    // 내부 replay 응답 → waiter 로, client 로는 안 보냄.
+    // An internal replay response goes to the waiter, never to the client.
     if (msg && typeof msg.id === 'string' && waiters.has(msg.id)) { const r = waiters.get(msg.id); waiters.delete(msg.id); r(msg); return; }
-    // client 원본 액션 응답 → 성공 시 기록.
+    // Response to the client's original action -> record it on success.
     if (msg && msg.id != null && pending.has(msg.id)) {
       const call = pending.get(msg.id); pending.delete(msg.id);
       const isErr = msg.result && msg.result.isError;
       if (!isErr && !msg.error) recording.push(call);
     }
-    // tools/list 응답 → 스킬 툴 주입.
+    // tools/list response -> inject skill tools.
     if (msg && msg.result && Array.isArray(msg.result.tools)) {
       const have = new Set(msg.result.tools.map((t) => t.name));
       for (const st of SKILL_TOOLS) if (!have.has(st.name)) msg.result.tools.push(st);

--- a/agentlas_cloud/update.py
+++ b/agentlas_cloud/update.py
@@ -37,8 +37,9 @@ HEALTHCHECK_TIMEOUT_SECONDS = 15
 MEMORY_HOOK_SYNC_TIMEOUT_SECONDS = 30
 MAX_RUNTIME_ARCHIVE_BYTES = 256 * 1024 * 1024
 # schemas/ carries the Workforce/Network contract files (workforce-work-order
-# 등). 2026-07-16 실측: 릴리스 아카이브에는 포함·강제되는데 이 목록에 없어서
-# 설치본에서만 통째로 유실 → 관리형 런타임의 hep-network가 스키마 결손으로 정지.
+# and others). Measured 2026-07-16: the release archive includes and enforces
+# this, but it was missing from this list, so it was lost entirely from
+# installs — a managed runtime's hep-network then stopped on a missing schema.
 RUNTIME_DIRS = ("bin", "agentlas_cloud", "career_graph", "ontology", "templates")
 RUNTIME_OPTIONAL_DIRS = ("schemas",)
 RUNTIME_FILES = ("package-contract.json",)
@@ -531,8 +532,8 @@ def fetch_latest_release(force: bool = False, ttl_seconds: int = DEFAULT_TTL_SEC
         # The TTL cache is an optimization, never part of the answer. Host
         # sandboxes (Claude Code, Codex, Cursor, ...) deny writes outside the
         # workspace, and a denied cache write must not discard a release fetch
-        # that already succeeded — 2026-07-29 실측: 이 쓰기가 샌드박스에서
-        # hep-update --check까지 통째로 죽이고 있었다.
+        # that already succeeded — measured 2026-07-29: this write was killing
+        # hep-update --check entirely inside a sandbox.
         pass
     return release
 

--- a/agentlas_cloud/upload.py
+++ b/agentlas_cloud/upload.py
@@ -517,10 +517,12 @@ def register_package(
                     raise UploadError(
                         f"Agentlas Cloud registration failed HTTP {retry_exc.code} after precondition retry: {retry_detail}"
                     ) from retry_exc
-        # BYOM 반복 교정 루프의 CLI 절반: 서버는 업로드 중 플랫폼 LLM을 부르지 않고
-        # 불일치 목록 + 핀 온톨로지 메뉴를 돌려준다. 이 메시지를 읽는 것은 업로드를
-        # 실행 중인 제출자의 자기 모델이므로, 800자 캡에 가이드가 잘리면 루프가
-        # 죽는다 — 전문을 구조화해 그대로 전달한다.
+        # The CLI half of the BYOM repair-retry loop: the server never calls a
+        # platform LLM during upload, it returns a mismatch list plus the
+        # pinned ontology menu. The one reading this message is the
+        # submitter's own model driving the upload, so truncating the
+        # guidance at an 800-char cap would kill the loop — pass the full,
+        # structured message through untouched.
         if exc.code == 422:
             try:
                 body = json.loads(detail)
@@ -567,8 +569,9 @@ def refresh_routing_card_metadata(base: Path) -> dict[str, Any]:
         return {"updated": False, "reason": "invalid_routing_card"}
 
     before = json.dumps(card, sort_keys=True, ensure_ascii=False)
-    # 이력서(workforce) 블록이 없는 카드는 결정적 최소 블록으로 채운다 — 자동 빌드
-    # 에이전트가 새 표준 게이트에서 죽지 않게 하는 관문(모델 호출 없음, 기존 블록 보존).
+    # A card with no résumé (workforce) block gets filled with a deterministic
+    # minimal block — a gate that keeps an auto-built agent from dying at the
+    # new standard gate (no model call, preserves any existing block).
     from .networking.card_lint import ensure_workforce_block
 
     ensure_workforce_block(card)

--- a/agentlas_cloud/workforce/execution.py
+++ b/agentlas_cloud/workforce/execution.py
@@ -43,12 +43,14 @@ _MAX_DIGEST_VALUE_NODES = 10_000
 def _is_valid_effort(value: Any) -> bool:
     """Same open vocabulary as model_allocation.normalize_effort.
 
-    2026-07-28 실측 드리프트: 이 파일의 예전 `_EFFORTS` 고정 집합은 "minimal"이 빠져
-    있었다 — model_allocation.py의 정본 튜플·MCP 스키마 어디에도 있는 값인데 여기서만
-    누락돼, 정상 해석된 "minimal" effort가 실행 영수증 검증에서 매번 거절됐다. 손으로
-    다시 베낀 닫힌 집합이 서로 어긋나는 바로 그 실패 양상이라, 값 하나를 추가하는 대신
-    검증 자체를 model_allocation의 단일 신택스 검사기로 옮겼다 — 다음에 provider가 새
-    리즌 레벨을 내놔도(예: "ultra") 이 파일을 다시 고칠 필요가 없다.
+    Measured drift, 2026-07-28: this file's old fixed `_EFFORTS` set was
+    missing "minimal" — a value present in model_allocation.py's canonical
+    tuple and in the MCP schema, but nowhere here, so a correctly resolved
+    "minimal" effort was rejected on every execution-receipt validation. That
+    is exactly the failure mode of a hand-copied closed set drifting out of
+    sync, so instead of adding one more value, validation itself moved onto
+    model_allocation's single syntax checker — the next time a provider ships
+    a new reason level (say, "ultra"), this file never needs touching again.
     """
     return value is None or (isinstance(value, str) and bool(EFFORT_TOKEN_RE.fullmatch(value)))
 

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/brief/shape.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/brief/shape.py
@@ -31,7 +31,7 @@ __all__ = ["classify_shape", "find_row_verdict", "SHAPES"]
 SHAPES = ("ledger", "verdict", "dossier", "computation", "blueprint", "rendition", "other")
 
 # A judgement property is one whose value space is a small closed set. The name is
-# irrelevant - `severity`, `status`, `verdict`, `등급` and `risk_tier` all qualify by
+# irrelevant - `severity`, `status`, `verdict`, `grade` and `risk_tier` all qualify by
 # having few allowed values, and a free-text field never does however it is named.
 _MAX_VERDICT_VALUES = 12
 

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/cli.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/cli.py
@@ -445,7 +445,7 @@ def main(argv: list[str] | None = None) -> int:
         "--scope",
         choices=["network", "cloud"],
         default="network",
-        help="network = public Hub marketplace; cloud = the signed-in owner's OWN cloud packages (보관함). cloud implies --hub-only (/hep-cloud).",
+        help="network = public Hub marketplace; cloud = the signed-in owner's OWN cloud packages. cloud implies --hub-only (/hep-cloud).",
     )
     route.add_argument(
         "--caller",
@@ -1014,8 +1014,8 @@ def main(argv: list[str] | None = None) -> int:
             # contracts, project-soul-memory.md, credentials/ and signing/
             # scaffolding — and rewrote .gitignore, with no consent and no notice.
             # Terminal already refuses to do this (it calls its own boundary with
-            # "read" permission and comments "context 명령은 프로젝트를 초기화하지
-            # 않는다"); Core was overriding that boundary from underneath.
+            # "read" permission and comments "the context command does not
+            # initialize a project"); Core was overriding that boundary from underneath.
             # Refresh an existing project, never conjure a new one.
             already_initialized = bool(
                 (Path(args.project).expanduser().resolve() / ".agentlas").is_dir()

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/interview/lenses.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/interview/lenses.py
@@ -15,28 +15,28 @@ from typing import Any
 
 LENS_GROUPS: dict[str, list[dict[str, str]]] = {
     "scope": [
-        {"id": "negative_space", "find": "언급되지 않은 인접 영역", "ko": "X는 언급 안 하셨는데, 의도적으로 뺀 건가요?", "en": "You didn't mention X — deliberately out of scope?"},
-        {"id": "minimum_version", "find": "과설계", "ko": "80%를 해결하는 가장 작은 버전은 뭔가요?", "en": "What is the smallest version that solves 80%?"},
-        {"id": "anti_scope", "find": "하면 안 되는 인접 작업 (anti_triggers 원천)", "ko": "비슷해 보여도 '이건 하면 안 된다'가 있다면요?", "en": "Anything that looks similar but must NOT be done?"},
-        {"id": "done_signal", "find": "끝의 정의", "ko": "뭘 보면 '됐다'고 판단하실 건가요?", "en": "What will you look at to call this done?"},
+        {"id": "negative_space", "find": "unmentioned adjacent area", "ko": "X는 언급 안 하셨는데, 의도적으로 뺀 건가요?", "en": "You didn't mention X — deliberately out of scope?"},
+        {"id": "minimum_version", "find": "over-engineering", "ko": "80%를 해결하는 가장 작은 버전은 뭔가요?", "en": "What is the smallest version that solves 80%?"},
+        {"id": "anti_scope", "find": "adjacent work that must not be done (source of anti_triggers)", "ko": "비슷해 보여도 '이건 하면 안 된다'가 있다면요?", "en": "Anything that looks similar but must NOT be done?"},
+        {"id": "done_signal", "find": "definition of done", "ko": "뭘 보면 '됐다'고 판단하실 건가요?", "en": "What will you look at to call this done?"},
     ],
     "system": [
-        {"id": "dependency_chain", "find": "숨은 결합", "ko": "X가 실패하면 같이 부서지는 게 뭔가요?", "en": "If X fails, what breaks with it?"},
-        {"id": "existing_assets", "find": "중복 구축", "ko": "이미 있는 Y를 확장할까요, 새로 만들까요?", "en": "Extend the existing Y, or build new?"},
-        {"id": "time_horizon", "find": "단기 해법의 부채", "ko": "3개월 뒤에도 이 결정이 유효한가요?", "en": "Will this decision still hold in 3 months?"},
-        {"id": "failure_mode", "find": "예외 경로", "ko": "가장 흔하게 잘못될 상황은 뭔가요?", "en": "What is the most common way this goes wrong?"},
+        {"id": "dependency_chain", "find": "hidden coupling", "ko": "X가 실패하면 같이 부서지는 게 뭔가요?", "en": "If X fails, what breaks with it?"},
+        {"id": "existing_assets", "find": "duplicate build", "ko": "이미 있는 Y를 확장할까요, 새로 만들까요?", "en": "Extend the existing Y, or build new?"},
+        {"id": "time_horizon", "find": "short-term-fix debt", "ko": "3개월 뒤에도 이 결정이 유효한가요?", "en": "Will this decision still hold in 3 months?"},
+        {"id": "failure_mode", "find": "exception path", "ko": "가장 흔하게 잘못될 상황은 뭔가요?", "en": "What is the most common way this goes wrong?"},
     ],
     "intent": [
-        {"id": "goal_of_goal", "find": "표층 요청 뒤 진짜 목표", "ko": "이게 되면 그다음에 뭘 하실 건가요?", "en": "Once this works, what happens next?"},
-        {"id": "audience", "find": "산출물의 소비자", "ko": "결과물을 누가 보나요/쓰나요?", "en": "Who consumes the output?"},
-        {"id": "rejected_alternatives", "find": "이미 시도한 것", "ko": "이미 해봤는데 안 됐던 방법이 있나요?", "en": "What have you already tried that didn't work?"},
-        {"id": "confidence_level", "find": "사실 vs 추정", "ko": "그건 확인된 사실인가요, 느낌인가요?", "en": "Is that a verified fact or a hunch?"},
+        {"id": "goal_of_goal", "find": "the real goal behind the surface request", "ko": "이게 되면 그다음에 뭘 하실 건가요?", "en": "Once this works, what happens next?"},
+        {"id": "audience", "find": "consumer of the output", "ko": "결과물을 누가 보나요/쓰나요?", "en": "Who consumes the output?"},
+        {"id": "rejected_alternatives", "find": "what's already been tried", "ko": "이미 해봤는데 안 됐던 방법이 있나요?", "en": "What have you already tried that didn't work?"},
+        {"id": "confidence_level", "find": "fact vs. assumption", "ko": "그건 확인된 사실인가요, 느낌인가요?", "en": "Is that a verified fact or a hunch?"},
     ],
     "challenge": [
-        {"id": "premortem", "find": "실패 시나리오", "ko": "6개월 뒤 실패했다고 치죠. 왜였을까요?", "en": "It failed six months from now — why?"},
-        {"id": "inversion", "find": "필수 회피 조건", "ko": "확실히 망치려면 뭘 하면 되나요?", "en": "What would guarantee failure?"},
-        {"id": "stop_criterion", "find": "손절 조건", "ko": "어떤 결과가 나오면 '그만두자'인가요?", "en": "What result would make you stop?"},
-        {"id": "forced_tradeoff", "find": "우선순위", "ko": "속도와 품질이 부딪히면 어느 쪽인가요?", "en": "When speed and quality collide, which wins?"},
+        {"id": "premortem", "find": "failure scenario", "ko": "6개월 뒤 실패했다고 치죠. 왜였을까요?", "en": "It failed six months from now — why?"},
+        {"id": "inversion", "find": "condition that must be avoided", "ko": "확실히 망치려면 뭘 하면 되나요?", "en": "What would guarantee failure?"},
+        {"id": "stop_criterion", "find": "cut-loss condition", "ko": "어떤 결과가 나오면 '그만두자'인가요?", "en": "What result would make you stop?"},
+        {"id": "forced_tradeoff", "find": "priority", "ko": "속도와 품질이 부딪히면 어느 쪽인가요?", "en": "When speed and quality collide, which wins?"},
     ],
 }
 

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/mcp_stdio.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/mcp_stdio.py
@@ -113,12 +113,15 @@ def _workforce_tool_contracts(*kinds: str) -> dict[str, dict[str, Any]]:
 
 
 def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
-    """검증 도구 전용 selection 스키마 — 순번 지정(candidateOrdinal)을 허용한다.
+    """Selection schema for verification tools only — allows specifying an
+    ordinal (candidateOrdinal) instead of a release ID.
 
-    canonical schemas/workforce-selection.schema.json 은 건드리지 않는다(허브·터미널
-    계약). 이 완화는 MCP 도구 입력에서만 유효하고, 핸들러가 순번을 저장된 명부로
-    정확한 agentReleaseId 로 해석한 뒤 canonical 형태로 심층 검증에 넘긴다.
-    48-hex ID 수기 복사는 실측된 오사 표면이다(2026-07-28 qwen 12회 중 1회 ID 절단).
+    Does not touch the canonical schemas/workforce-selection.schema.json (the
+    Hub/Terminal contract). This relaxation is valid only for MCP tool input;
+    the handler resolves the ordinal against the stored menu into the exact
+    agentReleaseId, then passes the canonical shape on to deep validation.
+    Hand-copying a 48-hex ID is a measured error surface (2026-07-28: 1 of 12
+    qwen attempts truncated the ID).
     """
     schema = _contract_property("selection", description)
     try:
@@ -128,7 +131,7 @@ def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
             "type": "integer",
             "minimum": 1,
             "maximum": 100,
-            "description": "명부에 부여된 후보 순번. agentReleaseId 대신 지정 가능 — 서버가 저장된 세션 명부에서 정확한 릴리스로 해석한다.",
+            "description": "The candidate's ordinal in the menu. May be given instead of agentReleaseId — the server resolves it to the exact release from the stored session menu.",
         }
     except (KeyError, TypeError):
         pass
@@ -137,25 +140,33 @@ def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
 
 _MENU_AUDIT_FIELDS = ("qualificationEvidence", "packageHash", "contentDigest")
 
-# semanticSnapshot 안의 중량 칸. 카드가 문장을 통째로 artifact ID로 슬러그화해 담는
-# 자리라 후보 1명이 수십 개를 싣는데, 후보끼리 겹치지 않아 대조 자체가 불가능하다
-# (라이브 1슬롯 10후보 실측: produces 고유 365개 중 2명 이상 공유 1개=0%, consumes
-# 149개 중 0개). 같은 내용은 summaries가 한 문장으로 이미 갖고 있고, 실제 매칭은
-# Core가 세션 저장소 원본으로 수행한다. 따라서 명부에서는 개수만 남긴다.
+# Heavyweight fields inside semanticSnapshot. This is where a card stuffs a
+# whole sentence slugified into an artifact ID, so a single candidate can
+# carry dozens of them — and since candidates never overlap, comparing them is
+# not even possible in the first place (measured live, 1 slot with 10
+# candidates: 0% of 365 unique `produces` values shared by 2+ candidates, 0 of
+# 149 for `consumes`). The same content is already in the summaries as one
+# sentence, and actual matching is done by Core against the session store's
+# original data. So the menu keeps only the count.
 _MENU_SNAPSHOT_HEAVY_FIELDS = ("produces", "consumes")
 
 
 def _menu_projection(result: dict[str, Any]) -> dict[str, Any]:
-    """검색 응답을 결정용 요약 명부로 투영 — 드롭리스트 방식.
+    """Projects a search response into a decision-ready summary menu — a
+    drop-list approach.
 
-    "남길 것"을 열거하지 않고 감사 중량 필드만 뺀다: 에이전트 속성(카드 스키마)이
-    추가·개명돼도 새 필드는 자동 통과한다. 원본 전문은 Core 세션 저장소가 보유하며
-    검증·준비의 핀 대조는 저장소 원본으로 수행되므로 통제 손실이 없다.
-    실측(1슬롯 10후보): 41,216B → 약 22KB, 판단 실효 정보 손실 0.
+    Instead of enumerating what to keep, it drops only the audit-weight
+    fields: if an agent attribute (card schema) is added or renamed, the new
+    field passes through automatically. Core's session store holds the full
+    original text, and validation/preparation pin-matching is performed
+    against that original data, so no control is lost.
+    Measured (1 slot, 10 candidates): 41,216B -> about 22KB, zero loss of
+    decision-relevant information.
 
-    이 투영은 MCP 표면 전용이다. 터미널 러너는 semanticSnapshot 키 집합을 정확히
-    9개로 단언하므로(agentlas-workforce.cjs assertExactKeys), 같은 접기를 Core
-    공용 경로에 넣으면 그쪽이 candidate_set_invalid로 죽는다.
+    This projection is MCP-surface only. The Terminal runner asserts the
+    semanticSnapshot key set at exactly 9 keys
+    (agentlas-workforce.cjs assertExactKeys), so applying the same folding on
+    Core's shared path would make that side die with candidate_set_invalid.
     """
     projected = {key: value for key, value in result.items() if key != "candidateProvenance"}
     candidate_set = projected.get("candidateSet")
@@ -197,10 +208,11 @@ def _resolve_ordinal_assignments(
     selection: Mapping[str, Any],
     candidate_set: Mapping[str, Any],
 ) -> tuple[dict[str, Any] | None, str | None]:
-    """assignments의 candidateOrdinal을 저장된 명부로 정확한 릴리스 ID로 해석한다.
+    """Resolves each assignment's candidateOrdinal against the stored menu into an exact release ID.
 
-    반환: (canonical 형태로 정규화된 selection, None) 또는 (None, 거절 코드).
-    순번과 릴리스 ID를 동시에 줬는데 서로 다르면 조용히 한쪽을 고르지 않고 거절한다.
+    Returns: (selection normalized to canonical shape, None) or (None, a
+    refusal code). If both an ordinal and a release ID were given and they
+    disagree, this refuses rather than silently picking one.
     """
     slots_by_id: dict[str, list[Mapping[str, Any]]] = {}
     for slot in candidate_set.get("slots", []) or []:
@@ -490,7 +502,7 @@ TOOLS: list[dict[str, Any]] = [
     {
         "name": "hephaestus_cloud_search",
         "description": (
-            "Search ONLY the signed-in user's OWN Agentlas cloud packages (보관함) "
+            "Search ONLY the signed-in user's OWN Agentlas cloud packages "
             "and return a JSON decision with a receipt_id. This is the owner-scoped "
             "leg of the three-scope model: it skips local cards and the public "
             "marketplace, querying the Hub with the owner filter (cargo.*). The "
@@ -517,7 +529,7 @@ TOOLS: list[dict[str, Any]] = [
         "inputSchema": {
             "type": "object",
             "properties": {
-                "request": {"type": "string", "description": "Search request, for example: 시장 리포트 쓸 에이전트 찾아줘."},
+                "request": {"type": "string", "description": "Search request, for example: find an agent that can write a market report."},
                 "project_dir": {"type": "string", "description": "Project directory for context (default: cwd)."},
                 "limit": {"type": "integer", "description": "Candidates per section. Default 10."},
             },
@@ -1773,9 +1785,10 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                     "status": "error",
                     "error": getattr(exc, "code", "workforce_source_search_failed"),
                 }
-            # 기본은 결정용 요약 명부(투영). 원본 전문은 세션 저장소가 보유하므로
-            # 검증·준비의 핀 대조는 손실 없다. 레거시 전량-에코 흐름이 필요한
-            # 호출자만 fullDossier=true 로 원형을 받는다.
+            # Default is the decision-ready summary menu (projection). The
+            # session store holds the full original text, so validation/
+            # preparation pin-matching loses nothing. Only a caller that needs
+            # the legacy full-echo flow gets the original shape via fullDossier=true.
             if arguments.get("fullDossier") is True:
                 return search_result
             return _menu_projection(search_result)
@@ -1828,15 +1841,18 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                 stored_set = federation_result.get("candidateSet")
                 if isinstance(stored_set, Mapping):
                     candidate_set = stored_set
-            # 순번 지정 해석 — 48-hex ID 수기 복사 대신 명부 순번으로 후보를 지정할 수
-            # 있다. 여기서 저장된(또는 제출된) 명부로 정확한 릴리스 ID로 해석해
-            # canonical 형태로 만든 뒤에만 심층 검증에 넘긴다. 해석 실패는 조용한
-            # 대체 없이 거절한다.
+            # Ordinal resolution — lets a candidate be specified by its menu
+            # ordinal instead of hand-copying a 48-hex ID. Resolves it against
+            # the stored (or submitted) menu into the exact release ID, into
+            # canonical shape, and only then passes it on to deep validation.
+            # A resolution failure is refused, with no silent substitute.
             #
-            # prepare에도 같이 건다. validate 전용이던 동안, 순번으로 결재해 accepted를
-            # 받은 호출자가 같은 selection을 prepare에 넘기면 assignments[0].agentReleaseId
-            # 누락 + candidateOrdinal additionalProperties로 거절당했다(실측). validate는
-            # canonical 형태를 돌려주지 않으므로 호출자에게는 되돌릴 방법이 없었다.
+            # This is applied to prepare too. While it was validate-only, a
+            # caller who got an "accepted" verdict by ordinal, then passed the
+            # same selection to prepare, was refused with a missing
+            # assignments[0].agentReleaseId plus a candidateOrdinal
+            # additionalProperties error (measured). validate does not return
+            # the canonical shape, so the caller had no way to recover.
             if (
                 name in ("workforce.validate_selection", "workforce.prepare_execution")
                 and isinstance(selection, Mapping)
@@ -1969,14 +1985,17 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                             "repairable": True,
                             "hubCalls": 0,
                         }
-                    # prepareAttempt의 idempotencyKey는 payload 전체의 canonical
-                    # sha256이라 호스트 LLM이 손으로 만들 수 없는 값이다(터미널
-                    # 러너는 코드로 계산한다). MCP 호스트 경로에서는 미제공 시
-                    # Core가 같은 재료 — 정확한 WorkOrder/해석된 Selection의
-                    # canonical digest, federatedSelection의 수령 digest·소스 핀 —
-                    # 로 파생한다. occurrenceId를 selectionSessionId에서 파생하므로
-                    # 같은 세션의 재시도는 같은 키로 떨어져 멱등성이 유지된다.
-                    # 제공된 prepareAttempt는 그대로 대조 검증한다(약화 없음).
+                    # prepareAttempt's idempotencyKey is the canonical sha256
+                    # of the entire payload — a value a host LLM cannot
+                    # compute by hand (the Terminal runner computes it in
+                    # code). On the MCP host path, when it's not supplied,
+                    # Core derives it from the same material — the exact
+                    # WorkOrder / resolved Selection's canonical digest, plus
+                    # federatedSelection's received digest and source pins.
+                    # occurrenceId is derived from selectionSessionId, so a
+                    # retry within the same session lands on the same key and
+                    # idempotency is preserved. A supplied prepareAttempt is
+                    # matched and validated as-is (no weakening).
                     prepare_attempt = arguments.get("prepareAttempt")
                     if prepare_attempt is None:
                         from .workforce.prepare_cache import prepare_attempt_payload
@@ -2000,8 +2019,9 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                                     ],
                                 )
                             except Exception:
-                                # 파생 실패는 조용한 대체 없이 기존 필수-인자
-                                # 검증 경로가 정직하게 거절하도록 남겨 둔다.
+                                # A derivation failure is left for the
+                                # existing required-argument validation path
+                                # to refuse honestly, with no silent substitute.
                                 prepare_attempt = None
                     service = WorkforceSourceService(session_store=store)
                     source_bundles = service.fetch_selected_runtime_bundles(
@@ -2162,7 +2182,7 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         return with_bootstrap(decision)
     if name == "hephaestus_cloud_search":
         # Owner-scoped: scope="cloud" implies hub_only inside route_request and
-        # queries only the signed-in user's OWN cloud packages (보관함).
+        # queries only the signed-in user's OWN cloud packages.
         # This routes, so it owes the same Work Brief contract as
         # hephaestus_route / `route --scope cloud`: same project_dir, same
         # brief, same reason on the way back when the brief cannot be used.

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/memory_contract.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/memory_contract.py
@@ -2,7 +2,7 @@
 memory rework, so the three surfaces (Desktop TS, Terminal CJS, hep Python) do
 not silently drift.
 
-Background: the memory logic lives in three places (CLAUDE.md "3제품 싱크" pattern,
+Background: the memory logic lives in three places (CLAUDE.md "3-product sync" pattern,
 extended here to the memory contract). The hep plugin is a lighter, per-slug
 implementation, but the *contracts* it produces on disk — the
 ``.agentlas/evolution-proposals.json`` shape, the ``context_source`` marker

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/memory_hook.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/memory_hook.py
@@ -212,10 +212,12 @@ def _source_path(item: dict[str, Any]) -> Path | None:
 def _source_staleness(item: dict[str, Any]) -> tuple[str | None, str | None]:
     """(inline age tag, staleness directive) for one cited source document.
 
-    2026-07-29 사고: 인덱스 문서가 12일 전에 동결됐는데 캡슐이 그 사실을 어디에도
-    표기하지 않아, 세션이 7/17 시점 사실을 현재로 단정했다. 나이는 캡슐 소비자가
-    추론할 수 없는 정보이므로 반드시 생산자가 라벨로 실어야 한다. Fail-open:
-    판별 불가능한 소스는 조용히 무표기(경고 오발보다 낫다).
+    2026-07-29 incident: the index document had been frozen for 12 days, but
+    the capsule carried no signal of that anywhere, so a session asserted
+    facts from 7/17 as current. Age is not something a capsule consumer can
+    infer, so the producer must always attach it as a label. Fail-open: a
+    source whose age can't be determined stays silently unlabeled rather than
+    risking a false staleness warning.
     """
 
     path = _source_path(item)
@@ -429,10 +431,12 @@ def build_capsule(
     if not lines and not evolution_line and not workforce_lines and not context_slice_line:
         return None, binding_root
     adapter_name, retrieval_status = _adapter_status(agent_result or project_result)
-    # 방출 계약: 판단은 세션 LLM이, 전달은 시스템이. .agentlas/pm은 이 백스톱
-    # 인덱스와 Desktop 인덱스가 모두 임베드하는 folder-shared 층이라, 여기 적힌
-    # 학습은 다음 세션부터 모든 호스트·제품의 recall로 돌아온다 (2026-07-29
-    # 실측: 실작업 학습이 이 층 밖에만 쌓여 소울·큐레이터가 굶었다).
+    # Emission contract: judgment is the session LLM's job, delivery is the
+    # system's. .agentlas/pm is a folder-shared layer that both this backstop
+    # index and the Desktop index embed, so a learning written here flows back
+    # into recall for every host and product starting the next session
+    # (measured 2026-07-29: real task learnings that only piled up outside
+    # this layer starved the Soul and Curator).
     emit_line = (
         "emit=after substantial work, record durable project learnings "
         "(fact/decision/procedure WITH evidence; never secrets or transcripts) as markdown in "

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/model_allocation.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/model_allocation.py
@@ -17,12 +17,15 @@ from typing import Any, Mapping
 
 SCHEMA_VERSION = "agentlas.model-allocation-decision.v1"
 TIERS = ("economy", "balanced", "frontier")
-# 알려진 값은 정책 상한과 비교할 "랭크 폴백"으로만 쓴다 — "유효한가" 게이트로 쓰지 않는다.
-# 2026-07-28 라이브 실측: codex debug models가 gpt-5.6-sol에서 "ultra"(자동 위임) 리즌
-# 레벨을 실제로 광고했다. 이 튜플로 게이트를 걸면 provider가 이미 출시한 값을 우리가
-# 스키마 검증 단계에서 조용히 거절한다(전체 decision이 invalid_effort로 폐기됨). 새 값이
-# 나올 때마다 이 튜플을 고치는 대신, 세션 인벤토리가 보고하는 모델 자체 순서(=능력 랭크,
-# provider 계약)를 신뢰하는 쪽으로 옮겼다 — 아래 normalize_effort/_bounded_effort 참고.
+# The known values are used only as a "rank fallback" to compare against a
+# policy ceiling — never as a validity gate. Measured live 2026-07-28: codex
+# debug models actually advertised an "ultra" (auto-delegate) reason level on
+# gpt-5.6-sol. Gating on this tuple would have us silently reject a value the
+# provider already shipped, at the schema-validation step (discarding the
+# whole decision as invalid_effort). Instead of patching this tuple every time
+# a new value appears, validation moved to trusting the model's own ordering
+# as reported by the session inventory (= capability rank, a provider
+# contract) — see normalize_effort/_bounded_effort below.
 EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 EFFORT_TOKEN_RE = re.compile(r"^[a-z][a-z0-9-]{0,23}$")
 PHASES = ("plan", "execute", "verify", "synthesize", "route", "clarify")
@@ -48,7 +51,7 @@ INVOCATION_STAGE_PHASES = {
     "clarify": "clarify",
 }
 TIER_RANK = {tier: index for index, tier in enumerate(TIERS)}
-# 알려진 값의 폴백 랭크만 — 미지의 값을 이 표로 거절하지 않는다(_bounded_effort 참고).
+# Fallback rank for known values only — an unknown value is never rejected by this table (see _bounded_effort).
 EFFORT_RANK = {effort: index for index, effort in enumerate(EFFORTS)}
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@-]{2,255}$")
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -126,9 +129,11 @@ def normalize_tier(value: Any) -> str | None:
 
 
 def normalize_effort(value: Any) -> str | None:
-    # 신택스만 검증한다 — 화이트리스트 존재는 게이트로 쓰지 않는다(위 EFFORTS 주석).
-    # 이 함수는 parent-AI가 요청한 값과, 세션 인벤토리가 보고한 모델 자체 지원 목록
-    # 양쪽에 다 쓰인다 — 열어두면 두 경로 모두에서 새 값이 조용히 안 드롭된다.
+    # Validates syntax only — the existence of a whitelist is not used as a
+    # gate (see the EFFORTS comment above). This function is used both for a
+    # value the parent AI requested and for the model's own supported-value
+    # list as reported by the session inventory — keeping it open means a new
+    # value never gets silently dropped on either path.
     normalized = _text(value).lower()
     return normalized if EFFORT_TOKEN_RE.fullmatch(normalized) else None
 
@@ -460,9 +465,10 @@ def _bounded_effort(requested: str, supported: list[str], max_effort: str) -> tu
     if eligible:
         resolved = max(eligible, key=lambda item: _effort_rank(item, supported))
     else:
-        # 요청/상한 어느 쪽과도 동시에 맞는 값이 없다 — 모델이 제공하는 가장 낮은
-        # 값으로 최대한 보수적으로 내려간다(원래 폴백과 동일, 상한을 우선시해
-        # 요청보다 위로 에스컬레이션하지 않는다).
+        # Nothing matches both the request and the ceiling at once — fall
+        # back as conservatively as possible, to the lowest value the model
+        # offers (same as the original fallback; the ceiling takes priority,
+        # so this never escalates above what was requested).
         resolved = min(supported, key=lambda item: _effort_rank(item, supported))
     return resolved, resolved != requested
 
@@ -523,12 +529,15 @@ def resolve_model_allocation(
     inventory = _normalize_inventory(raw_inventory)
     policy = dict(policy or {})
     escalation_request, escalation_issues = _validate_escalation(escalation)
-    # maxEscalations는 부모가 선언한 비용 상한이다. 상한은 "권한을 주는 값"이 아니라
-    # "권한을 제한하는 값"이므로, 관계없는 검증 이슈(unknown_fields 등)가 하나만 섞여도
-    # 상한 검사를 통째로 건너뛰면 안 된다. 예전에는 `and not issues` 때문에 무관한
-    # 필드 하나가 상한을 무력화해 maxEscalations=0인 결정도 frontier/xhigh로 승격됐다.
-    # decision이 존재하면 selection.maxEscalations는 항상 정규화되어 있고(불량/누락은
-    # 기본값 0) 따라서 이슈가 있는 결정일수록 더 보수적으로 막힌다 — fail-closed.
+    # maxEscalations is a cost ceiling the parent declared. A ceiling is a
+    # value that restricts authority, not one that grants it, so a single
+    # unrelated validation issue (unknown_fields, etc.) mixed in must never
+    # skip the ceiling check entirely. Previously, `and not issues` let one
+    # irrelevant field disable the ceiling, so even a maxEscalations=0
+    # decision could be escalated to frontier/xhigh. Whenever a decision
+    # exists, selection.maxEscalations is always normalized (a bad or missing
+    # value defaults to 0), so a decision with issues is blocked more
+    # conservatively, not less — fail-closed.
     if (
         escalation_request is not None
         and decision is not None
@@ -554,8 +563,9 @@ def resolve_model_allocation(
         or "orchestrator"
     )
     if escalation_request is not None:
-        # 승격은 단계→역할 기본 매핑에 대한 유일한 허용 예외다. worker 단계의
-        # 마지막 재시도 한 번만 orchestrator 역할 정책으로 해석한다.
+        # Escalation is the one allowed exception to the default stage->role
+        # mapping. Only the last retry of a worker stage is interpreted under
+        # the orchestrator role policy.
         resolved_role = "orchestrator"
     role_policy, inherited_role_policy = _policy_for_role(policy, resolved_role)
     current_model_id = _text(role_policy.get("currentModelId"))
@@ -613,8 +623,9 @@ def resolve_model_allocation(
         else:
             reasons.append("pinned_model_unavailable_or_incompatible")
 
-    # 승격된 재시도는 worker 단계용 parent decision이 아니라 orchestrator 역할
-    # 정책이 지배한다 — decision은 맥락으로만 남고 모델 선택에는 쓰지 않는다.
+    # An escalated retry is governed by the orchestrator role policy, not the
+    # worker stage's parent decision — the decision stays only as context and
+    # is not used for model selection.
     if selected is None and decision is not None and not issues and escalation_request is None:
         requested_tier = decision["selection"]["tier"]
         if TIER_RANK[requested_tier] > TIER_RANK[max_tier]:
@@ -666,14 +677,17 @@ def resolve_model_allocation(
                 reasons.append("parent_exact_model_required_for_ambiguous_inventory")
 
     if selected is None and escalation_request is not None:
-        # 승격 재시도는 위 블록에서 parent decision을 의도적으로 건너뛴다. 그래서
-        # 운영자 핀(pinnedModelId)이 없으면 여기까지 어떤 분기도 selected를 채우지
-        # 못했고, 유일하게 허용된 재시도가 항상 unresolved로 죽었다 — 핀은 선택
-        # 사항이므로 핀을 두지 않은 모든 운영자에게 승격 계약 자체가 사문화된다.
-        # 핀이 없을 때도 orchestrator 역할 정책만으로 결정적으로 고른다: maxTier
-        # 이하 후보 중 최상위 tier를 쓰고("약모델 실패 → 강모델 승격"), 동률이면
-        # 역할의 현재 모델로 가른다. 정책 상한을 넘기지 않으므로 승격이 비용
-        # 가드레일을 뚫는 경로가 되지는 않는다.
+        # An escalation retry deliberately skips the parent decision in the
+        # block above. So without an operator pin (pinnedModelId), no branch
+        # up to this point had filled `selected`, and the one allowed retry
+        # always died as unresolved — since a pin is optional, this silently
+        # voided the escalation contract for every operator who didn't set
+        # one. Even with no pin, choose deterministically from the
+        # orchestrator role policy alone: use the highest tier among
+        # candidates at or below maxTier ("weak model failed -> escalate to a
+        # strong one"), breaking ties with the role's current model. This
+        # never exceeds the policy ceiling, so escalation is never a path
+        # around the cost guardrail.
         allowed = [
             item
             for item in compatible_inventory
@@ -702,9 +716,10 @@ def resolve_model_allocation(
         if decision is None or issues:
             reasons.append("parent_decision_missing_or_invalid")
         elif escalation_request is not None:
-            # 승격 경로는 parent decision의 모델을 요청하지 않는다. 여기서
-            # no_compatible_requested_model을 남기면 살아 있는 호환 모델을 두고도
-            # "요청 모델이 비호환"이라는 거짓 사유를 보고하게 된다.
+            # The escalation path never requests the parent decision's model.
+            # Recording no_compatible_requested_model here would report a
+            # false "the requested model is incompatible" reason even though
+            # a compatible model was actually available.
             reasons.append("escalation_target_unavailable")
         else:
             reasons.append("no_compatible_requested_model")
@@ -719,8 +734,10 @@ def resolve_model_allocation(
     risk = decision["features"]["risk"] if decision else "unknown"
     parent_reason_codes = list(decision["reasonCodes"]) if decision else []
     if escalation_request is None and "escalated-after-failure" in parent_reason_codes:
-        # 승격 없이 승격 사유코드만 오는 것은 계약 위반이다 — 조용히 통과시키면
-        # 소비자가 승격 필드 없는 승격을 믿게 된다. 사유코드를 떼고 이슈로 남긴다.
+        # An escalation reason code arriving with no actual escalation is a
+        # contract violation — passing it through silently would let a
+        # consumer believe an escalation happened with no escalation field.
+        # Strip the reason code and record it as an issue instead.
         escalation_issues.append("escalation_reason_code_without_escalation")
         parent_reason_codes = [code for code in parent_reason_codes if code != "escalated-after-failure"]
     if escalation_request is not None:

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/card_lint.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/card_lint.py
@@ -196,7 +196,7 @@ def lint_card(card: dict[str, Any]) -> dict[str, Any]:
     if bench_cases < 10:
         ready_blockers.append(f"needs >=10 benchmark cases (has {bench_cases})")
 
-    # 이력서(workforce) block — the hub standard résumé the Workforce search
+    # résumé (workforce) block — the hub standard résumé the Workforce search
     # matches on. Measured over the live catalog (2026-07-27) sellers declared
     # roles/modalities on 0 of 250 cards, so every WorkOrder using those fields
     # excluded the whole catalog. Built packages must ship the block filled;
@@ -205,9 +205,11 @@ def lint_card(card: dict[str, Any]) -> dict[str, Any]:
     # ontology snapshot supplies aliases/relations, not a profession allowlist.
     workforce = card.get("workforce")
     if not isinstance(workforce, dict):
-        # 자동 빌드 파이프라인(스톰 워커, 변환 패키징)은 블록을 손으로 못 쓴다 —
-        # 결정적 파생이 가능하므로 린트는 경고만 남기고, 하드 게이트는 서버
-        # 등록 경계(workforce_resume_incomplete)와 업로드 관문의 자동 채움이 맡는다.
+        # An automated build pipeline (Stormbreaker workers, conversion
+        # packaging) cannot hand-write this block. Since a deterministic
+        # derivation is possible, lint only warns — the hard gate is left to
+        # the server registration boundary (workforce_resume_incomplete) and
+        # the upload gate's auto-fill.
         derived = ensure_workforce_block(dict(card))
         workforce = derived["workforce"]
         warnings.append(

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/card_store.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/card_store.py
@@ -44,8 +44,9 @@ def save_card(home: Path, card: dict[str, Any]) -> Path:
     card["updated_at"] = card.get("updated_at") or utc_now()
     target = card_path(home, card)
     atomic_write_json(target, card)
-    # 데스크탑 핸드오프 — trusted local 등록은 수동 임포트 없이 Agentlas Desktop
-    # 라이브러리에 도달해야 한다(자격 미달/실패는 조용히 무시, 등록을 깨지 않음).
+    # Desktop handoff — a trusted local registration must reach the Agentlas
+    # Desktop library without a manual import (a failure or unmet requirement
+    # is silently ignored here rather than breaking the registration).
     enqueue_desktop_sync(home, card)
     return target
 

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/desktop_sync.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/desktop_sync.py
@@ -29,7 +29,8 @@ from .bootstrap import atomic_write_json, read_json, utc_now
 PENDING_DIR = "desktop-sync/pending"
 DONE_DIR = "desktop-sync/done"
 
-# 패키지 실체 확인용 마커 — 이 중 하나는 있어야 임포트 가능한 폴더로 본다.
+# Markers that confirm a real package — a folder must have at least one of
+# these to be treated as importable.
 _PACKAGE_MARKERS = ("agentlas.json", "AGENT.md", "AGENTS.md", "TEAM.md", "CLAUDE.md")
 
 
@@ -45,7 +46,8 @@ def _package_ref(card: dict[str, Any]) -> Path | None:
     if not raw:
         return None
     ref = Path(raw)
-    # reindex가 상대경로('.')를 남긴 이력이 있다 — 절대경로 + 실존 + 패키지 마커까지 요구.
+    # reindex has a history of leaving a relative path ('.') behind — require
+    # an absolute path, that it actually exists, and a package marker too.
     if not ref.is_absolute() or not ref.is_dir():
         return None
     if not any((ref / marker).is_file() for marker in _PACKAGE_MARKERS):

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/goal_loop.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/goal_loop.py
@@ -9,13 +9,13 @@ repetition is the point, not a defect.
 This module adds the missing half: a controller that auto-constructs a loop for a
 task and drives it **until the goal verifies**, while staying stable —
 
-- **don't break (안 끊기게):** a transient iteration failure does not kill the loop.
+- **don't break:** a transient iteration failure does not kill the loop.
   It is journaled and retried with backoff, up to `max_consecutive_failures` in a
   row. Only a genuine streak of hard failures stops the run.
 - **don't run away:** a hard `max_iterations` ceiling, plus stall detection —
   if `stall_window` consecutive iterations make no new progress, the loop stops as
   `stalled` instead of spinning forever. Progress is measured, not assumed.
-- **keep the goal until done (될때까지 목표 유지):** the loop only reports
+- **keep the goal until done:** the loop only reports
   `reached_goal` when the goal predicate verifies; it never claims success on a
   bare "it ran."
 - **survive a hard stop:** every iteration is a Run Journal step, so a killed loop

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/router.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/router.py
@@ -636,14 +636,17 @@ def _hub_query_has_fitting_borrowable(query_tokens: list[str], results: list[dic
     )
 
 
-# 일반적인 빌드/기획 동사는 "이 에이전트를 지목했다"고 볼 만큼 특이하지 않으므로 제외 —
-# 진짜 역할 단어("웹마스터", "카피라이터")로만 매칭한다.
+# Generic build/planning verbs are excluded — they aren't distinctive enough
+# to count as "this agent was explicitly named." Only real role words
+# ("webmaster", "copywriter") count as a match.
 _GENERIC_ROLE_TOKENS = {
     "기획", "제작", "개발", "구현", "빌드", "만들", "작업", "불러", "불러서", "해줘", "해",
     "팀", "웹", "앱", "사이트", "페이지", "랜딩", "랜딩페이지", "에이전트", "등",
     "agent", "team", "build", "make", "plan", "create", "page", "landing", "web", "app", "site",
-    # 제품/브랜드 주제어 — 요청의 '주제'이지 에이전트 '지목'이 아니다. 이게 없으면 "Agentlas에
-    # 대해서 글 써줘"에서 이름에 agentlas가 든 후보(PRD 메이커 등)를 "지목됨"으로 오판해 다 빌려온다.
+    # Product/brand topic words — these are the request's "topic," not an
+    # agent being "named." Without this, "write something about Agentlas"
+    # would misjudge any candidate with "agentlas" in its name (a PRD maker,
+    # etc.) as "named" and borrow all of them.
     "agentlas", "hephaestus", "oberon", "대해서", "대한", "관련",
 }
 
@@ -719,9 +722,11 @@ def _byom_execution_plan(
                 )
     else:
         borrowable = [item for item in (results or []) if _is_borrowable(item)]
-        # 사용자가 에이전트를 명시적으로 지목했으면("웹마스터 카피라이터 불러서") 전부 빌려온다 —
-        # 다중 역할 요청을 최상위 후보 1개로 축소하지 않는다(Hub가 오프도메인 에이전트를 명시된
-        # 에이전트보다 높게 랭크할 수 있으므로 명시 지목을 우선).
+        # If the user explicitly named agents (e.g. "call the webmaster and
+        # the copywriter"), borrow all of them — a multi-role request is never
+        # reduced to a single top candidate (the Hub can rank an off-domain
+        # agent above one that was explicitly named, so an explicit name
+        # takes priority).
         named = _explicitly_named_borrowables(query, borrowable)
         if named:
             for cand in named[:5]:
@@ -741,10 +746,12 @@ def _byom_execution_plan(
     # returning a task_force with execution=null.
     if not recommended and not stages:
         return None
-    # 명시 지목이 2개+면 이건 "여러 전문가가 협업하는 하나의 산출물" — 실행 모델이 임시
-    # 오케스트레이터 역할(plan→dispatch→synthesize)을 맡도록 directive를 전환한다. CLI에는
-    # 별도 오케스트레이터 세션이 없으므로(hep-storm --executor-command 없이는) 베이스 모델이
-    # 매니저가 되는 게 현실적 경로다.
+    # Two or more explicit names means this is "one deliverable from several
+    # specialists collaborating" — switch the directive so the execution
+    # model takes on a temporary orchestrator role (plan -> dispatch ->
+    # synthesize). The CLI has no separate orchestrator session (short of
+    # hep-storm --executor-command), so the base model becoming the manager
+    # is the realistic path.
     core_stages = [
         str(stage.get("stage"))
         for stage in (stages or [])
@@ -792,7 +799,7 @@ def _byom_execution_plan(
         )
     return {
         "mode": "byom_local_grounded",
-        # 다중 명시 지목이면 실행 모델이 매니저 역할을 맡는다는 신호.
+        # Multiple explicit names is the signal for the execution model to take on the manager role.
         "formation": "temporary_orchestrator" if multi else "single_specialist",
         "primary_agent": primary,
         "recommended_agents": recommended,
@@ -993,7 +1000,7 @@ def route_request(
 
     # Three-scope command model (docs/hephaestus-network-2.0.md):
     #   scope="cloud"   -> /hep-cloud: search ONLY the signed-in user's
-    #                     OWN cloud packages (보관함). Owner-scoped Hub query,
+    #                     OWN cloud packages. Owner-scoped Hub query,
     #                     implies hub_only (skip local + public marketplace).
     #   scope="network" -> /hep-network: search Cloud > Bookmark > public Hub
     #                     in that order. Used with hub_only by the network command.
@@ -1164,7 +1171,7 @@ def route_request(
         )
 
     if hub_only:
-        # The owner cloud (보관함) and the public marketplace share this
+        # The owner cloud and the public marketplace share this
         # Hub-only flow; the only difference is the scope passed to the Hub and
         # the receipt/reason tag, so /hep-cloud and /hep-network
         # stay one code path with two scopes.

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/router_agent_call.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/router_agent_call.py
@@ -53,9 +53,11 @@ def router_escalation(
         return None
     action = str(result.get("action") or "")
     hub_results = ((result.get("hub") or {}).get("results")) if isinstance(result.get("hub"), dict) else None
-    # hub_candidates 는 "후보를 찾았다"는 이유로 렉시컬 top-1 을 그대로 primary 로 밀지만,
-    # 렉시컬 점수는 브랜드/주제어에 쉽게 휘둘려 오선택한다("쓰레드 글 써줘"→PRD 메이커). 후보가 2개 이상이면
-    # 호스트 LLM 라우터에 넘겨 '의도 적합도'로 재정렬하게 한다(키워드 나열이 아니라 의미 기반 선택).
+    # hub_candidates pushes the lexical top-1 straight through as primary just
+    # because "a candidate was found," but a lexical score is easily thrown off
+    # by a brand name or topic word and mis-selects (e.g. "write a Threads
+    # post" -> a PRD maker). With two or more candidates, hand off to the host
+    # LLM router to re-rank by actual intent fit instead of keyword overlap.
     hub_multi = (
         action == "hub_candidates"
         and isinstance(hub_results, list)

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/package_contract.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/package_contract.py
@@ -371,7 +371,7 @@ def _verify_artifact(workspace: Path, artifact: dict[str, Any], base: Path) -> d
             source["ref"] = str(workspace)
         try:
             lint = lint_card({**doc, "source": source})
-        except Exception as err:  # 카드가 어떤 모양이든 게이트는 크래시하지 않는다
+        except Exception as err:  # the gate must not crash no matter what shape the card is
             lint = {"errors": [f"lint crashed on malformed card: {err}"], "ready_blockers": []}
         report["routing_lint"] = lint
         problems.extend(f"routing-card: {err}" for err in lint.get("errors", []))

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/project_bootstrap.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/project_bootstrap.py
@@ -1358,10 +1358,12 @@ def _bounded_project_map(project_map: dict[str, Any]) -> tuple[str, int]:
             key=lambda key: (-int(ref_counts.get(key) or 0), key),
         )
         original_refs = len(ordered)
-        # 바이트 예산이 계약이고 "최소 1,000개 유지"는 휴리스틱이다. 파일당 심볼
-        # 상한을 올린 뒤로는 이 바닥이 작은 예산과 교착해 맵 전체를 잃게 했다
-        # (예산 초과 = OSError = 맵 없음). ordered는 참조 빈도순이므로 바닥을
-        # 1로 내려도 가장 뜨거운 심볼부터 예산이 허락하는 만큼 남는다.
+        # The byte budget is the contract; "keep at least 1,000" is only a
+        # heuristic. Since the per-file symbol cap was raised, that floor has
+        # deadlocked against a small budget and lost the whole map (budget
+        # exceeded = OSError = no map). ordered is sorted by reference
+        # frequency, so lowering the floor to 1 still keeps as many of the
+        # hottest symbols as the budget allows.
         while len(raw.encode("utf-8")) > MAX_CODE_MAP_BYTES and len(ordered) > 1:
             ordered = ordered[: max(1, len(ordered) // 2)]
             allowed = set(ordered)
@@ -1374,9 +1376,10 @@ def _bounded_project_map(project_map: dict[str, Any]) -> tuple[str, int]:
             project_map["stats"]["outputTruncated"] = True
             project_map["stats"]["refIndexSymbolsOmitted"] = original_refs - len(allowed)
             raw = json.dumps(project_map, ensure_ascii=False, separators=(",", ":")) + "\n"
-    # 파일당 심볼 상한을 올린 뒤로는 defIndex/topSymbols 단독으로도 작은 예산을
-    # 넘을 수 있다. 사다리 뒤쪽에 두어 정의 색인이 가장 오래 살아남게 하되,
-    # 바이트 예산이 최종 계약이므로 여기서도 수렴할 때까지 절반씩 줄인다.
+    # Since the per-file symbol cap was raised, defIndex/topSymbols alone can
+    # now exceed a small budget too. This step comes last in the ladder so the
+    # definition index survives longest, but the byte budget is still the
+    # final contract, so keep halving until it converges here too.
     if len(raw.encode("utf-8")) > MAX_CODE_MAP_BYTES and isinstance(project_map.get("defIndex"), dict) and project_map["defIndex"]:
         def_counts = project_map.get("refCount") if isinstance(project_map.get("refCount"), dict) else {}
         ordered_defs = sorted(

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/project_index_backstop.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/project_index_backstop.py
@@ -156,9 +156,11 @@ def _read_bounded_text(path: Path, max_bytes: int) -> str | None:
 def _discover_pm_files(project_root: Path) -> list[tuple[str, str]]:
     """Bounded pm documents, session learnings first and newest first.
 
-    2026-07-29 실측: 이름순·루트우선 순회에서는 7월 중순의 대형 HANDOFF 문서가
-    48K자 예산을 먼저 소진해, 방금 기록한 `learnings/` 학습이 인덱스에 한 글자도
-    못 실렸다. recall 가치는 최신·학습 문서가 가장 크므로 그 순서로 예산을 쓴다.
+    Measured 2026-07-29: a name-ordered, root-first traversal let a large
+    mid-July HANDOFF document exhaust the 48K-character budget first, so a
+    learning recorded moments earlier never made it into the index at all.
+    Recall value is highest for the newest and the learnings documents, so
+    the budget is spent in that order.
     """
 
     pm_root = project_root / ".agentlas" / PM_DIR

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/agentlas_browser_launcher.mjs
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/agentlas_browser_launcher.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-// Agentlas Browser (CDP) — 범용 엔진. 실제 로그인 Chrome 전용 프로필을 원격 디버깅 포트로 띄우고
-// @playwright/mcp 를 CDP 로 붙여 MCP 브라우저 도구를 제공한다. 이 프로세스가 client ↔ @playwright/mcp
-// 사이를 stdio 로 프록시하며 (1) 되돌릴 수 없는 행동 승인 게이트, (2) learn-and-replay 스킬 레이어를 얹는다.
-// 의존성 0(순수 node). 개인 데이터는 로컬에서만 사용, 어디로도 전송하지 않는다.
+// Agentlas Browser (CDP) — general-purpose engine. Launches the real, already
+// logged-in Chrome profile with a remote debugging port, then attaches
+// @playwright/mcp over CDP to provide MCP browser tools. This process proxies
+// stdio between the client and @playwright/mcp, layering on (1) an approval
+// gate for irreversible actions, and (2) a learn-and-replay skill layer.
+// Zero dependencies (pure node). Personal data is used locally only and never sent anywhere.
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -86,7 +88,7 @@ async function ensureChrome() {
   throw new Error('Chrome CDP port did not open: ' + PORT);
 }
 
-// ── 승인 게이트 ──────────────────────────────────────────────────
+// ── approval gate ──────────────────────────────────────────────────
 // CONTRACT (fail-closed): the regexes below only LABEL the approval kind —
 // they never make the final "no gate needed" decision for a commit-like
 // action. A click/keypress/upload that submits, pays, sends, or deletes but
@@ -146,8 +148,8 @@ function requestApproval(site, actionType, summary) {
   });
 }
 
-// ── learn-and-replay 스킬 레이어 ─────────────────────────────────
-// 재생/기록 대상 액션 툴(읽기 전용 snapshot/screenshot 등은 제외).
+// ── learn-and-replay skill layer ─────────────────────────────────
+// Action tools eligible for recording/replay (excludes read-only ones like snapshot/screenshot).
 const RECORDABLE = new Set(['browser_navigate', 'browser_navigate_back', 'browser_click', 'browser_type', 'browser_fill', 'browser_fill_form', 'browser_select_option', 'browser_press_key', 'browser_hover', 'browser_file_upload', 'browser_drag']);
 const SKILL_TOOLS = [
   { name: 'browser_skill_list', description: 'List saved Agentlas browser skills (learned action sequences).', inputSchema: { type: 'object', properties: {} } },
@@ -171,15 +173,15 @@ async function main() {
   child.on('error', (e) => { log('failed to start @playwright/mcp', String(e)); process.exit(1); });
   child.on('exit', (code) => process.exit(code == null ? 0 : code));
 
-  const recording = [];            // 이 세션에서 성공한 액션 시퀀스
-  const pending = new Map();       // client 원본 tools/call: id -> {name, args}
-  const waiters = new Map();       // 내부(replay) tools/call: id -> resolve
+  const recording = [];            // sequence of actions that succeeded in this session
+  const pending = new Map();       // client's original tools/call: id -> {name, args}
+  const waiters = new Map();       // internal (replay) tools/call: id -> resolve
   let currentUrl = '';
   let internalSeq = 0;
   const writeClient = (obj) => { try { process.stdout.write(JSON.stringify(obj) + '\n'); } catch (e) {} };
   const forwardRaw = (line) => { try { child.stdin.write(line + '\n'); } catch (e) {} };
 
-  // 승인 게이트 통과 여부 판정(공유). 통과=null, 거부=사유문자열.
+  // Shared approval-gate verdict. Pass = null, refuse = reason string.
   const gate = async (name, args, preJudgedKind) => {
     const actionType = classifyAction(name, args, preJudgedKind);
     if (!actionType) return null;
@@ -191,7 +193,7 @@ async function main() {
     return decision === 'approved' ? null : actionType;
   };
 
-  // 내부에서 child 에 tools/call 을 보내고 응답을 받는다(replay 용).
+  // Internally sends a tools/call to the child and gets the response (for replay).
   const callChild = (name, args) => new Promise((resolve) => {
     const id = 'agx-' + (++internalSeq);
     waiters.set(id, resolve);
@@ -214,14 +216,14 @@ async function main() {
     writeClient({ jsonrpc: '2.0', id: replyId, result: { content: [{ type: 'text', text: 'Replayed skill "' + name + '" (' + (skill.steps || []).length + ' steps):\n' + results.join('\n') }] } });
   };
 
-  // client → child 방향
+  // client -> child direction
   const handleClientLine = (line) => {
     if (!line.trim()) { forwardRaw(line); return; }
     let msg; try { msg = JSON.parse(line); } catch (e) { forwardRaw(line); return; }
     if (msg && msg.method === 'tools/call' && msg.params) {
       const name = msg.params.name || '';
       const args = msg.params.arguments || {};
-      // 스킬 툴은 로컬 처리(child 로 안 보냄).
+      // Skill tools are handled locally (not sent to the child).
       if (name === 'browser_skill_list') { writeClient({ jsonrpc: '2.0', id: msg.id, result: { content: [{ type: 'text', text: JSON.stringify(listSkills()) }] } }); return; }
       if (name === 'browser_skill_save') {
         try { const doc = saveSkill(args.name, recording.slice(), args.description); writeClient({ jsonrpc: '2.0', id: msg.id, result: { content: [{ type: 'text', text: 'Saved skill "' + doc.name + '" with ' + doc.steps.length + ' steps → ' + skillPath(doc.name) }] } }); }
@@ -229,7 +231,7 @@ async function main() {
         return;
       }
       if (name === 'browser_skill_replay') { doReplay(args.name, msg.id); return; }
-      // 일반 액션: 승인 게이트 + 기록. 부모가 _meta 로 사전판정을 보냈으면 그 판정이 우선.
+      // Ordinary action: approval gate + record. If the parent sent a pre-judged verdict via _meta, that verdict wins.
       if (name === 'browser_navigate' && args.url) currentUrl = String(args.url);
       const preJudgedKind = (msg.params._meta || {})['agentlas/actionKind'];
       const actionType = classifyAction(name, args, preJudgedKind);
@@ -246,19 +248,19 @@ async function main() {
     forwardRaw(line);
   };
 
-  // child → client 방향 (응답 가로채기: replay waiter / 기록 / tools/list 주입)
+  // child -> client direction (intercepts responses: replay waiter / recording / tools/list injection)
   const handleChildLine = (line) => {
     if (!line.trim()) { process.stdout.write(line + '\n'); return; }
     let msg; try { msg = JSON.parse(line); } catch (e) { process.stdout.write(line + '\n'); return; }
-    // 내부 replay 응답 → waiter 로, client 로는 안 보냄.
+    // An internal replay response goes to the waiter, never to the client.
     if (msg && typeof msg.id === 'string' && waiters.has(msg.id)) { const r = waiters.get(msg.id); waiters.delete(msg.id); r(msg); return; }
-    // client 원본 액션 응답 → 성공 시 기록.
+    // Response to the client's original action -> record it on success.
     if (msg && msg.id != null && pending.has(msg.id)) {
       const call = pending.get(msg.id); pending.delete(msg.id);
       const isErr = msg.result && msg.result.isError;
       if (!isErr && !msg.error) recording.push(call);
     }
-    // tools/list 응답 → 스킬 툴 주입.
+    // tools/list response -> inject skill tools.
     if (msg && msg.result && Array.isArray(msg.result.tools)) {
       const have = new Set(msg.result.tools.map((t) => t.name));
       for (const st of SKILL_TOOLS) if (!have.has(st.name)) msg.result.tools.push(st);

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/update.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/update.py
@@ -37,8 +37,9 @@ HEALTHCHECK_TIMEOUT_SECONDS = 15
 MEMORY_HOOK_SYNC_TIMEOUT_SECONDS = 30
 MAX_RUNTIME_ARCHIVE_BYTES = 256 * 1024 * 1024
 # schemas/ carries the Workforce/Network contract files (workforce-work-order
-# 등). 2026-07-16 실측: 릴리스 아카이브에는 포함·강제되는데 이 목록에 없어서
-# 설치본에서만 통째로 유실 → 관리형 런타임의 hep-network가 스키마 결손으로 정지.
+# and others). Measured 2026-07-16: the release archive includes and enforces
+# this, but it was missing from this list, so it was lost entirely from
+# installs — a managed runtime's hep-network then stopped on a missing schema.
 RUNTIME_DIRS = ("bin", "agentlas_cloud", "career_graph", "ontology", "templates")
 RUNTIME_OPTIONAL_DIRS = ("schemas",)
 RUNTIME_FILES = ("package-contract.json",)
@@ -531,8 +532,8 @@ def fetch_latest_release(force: bool = False, ttl_seconds: int = DEFAULT_TTL_SEC
         # The TTL cache is an optimization, never part of the answer. Host
         # sandboxes (Claude Code, Codex, Cursor, ...) deny writes outside the
         # workspace, and a denied cache write must not discard a release fetch
-        # that already succeeded — 2026-07-29 실측: 이 쓰기가 샌드박스에서
-        # hep-update --check까지 통째로 죽이고 있었다.
+        # that already succeeded — measured 2026-07-29: this write was killing
+        # hep-update --check entirely inside a sandbox.
         pass
     return release
 

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/upload.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/upload.py
@@ -517,10 +517,12 @@ def register_package(
                     raise UploadError(
                         f"Agentlas Cloud registration failed HTTP {retry_exc.code} after precondition retry: {retry_detail}"
                     ) from retry_exc
-        # BYOM 반복 교정 루프의 CLI 절반: 서버는 업로드 중 플랫폼 LLM을 부르지 않고
-        # 불일치 목록 + 핀 온톨로지 메뉴를 돌려준다. 이 메시지를 읽는 것은 업로드를
-        # 실행 중인 제출자의 자기 모델이므로, 800자 캡에 가이드가 잘리면 루프가
-        # 죽는다 — 전문을 구조화해 그대로 전달한다.
+        # The CLI half of the BYOM repair-retry loop: the server never calls a
+        # platform LLM during upload, it returns a mismatch list plus the
+        # pinned ontology menu. The one reading this message is the
+        # submitter's own model driving the upload, so truncating the
+        # guidance at an 800-char cap would kill the loop — pass the full,
+        # structured message through untouched.
         if exc.code == 422:
             try:
                 body = json.loads(detail)
@@ -567,8 +569,9 @@ def refresh_routing_card_metadata(base: Path) -> dict[str, Any]:
         return {"updated": False, "reason": "invalid_routing_card"}
 
     before = json.dumps(card, sort_keys=True, ensure_ascii=False)
-    # 이력서(workforce) 블록이 없는 카드는 결정적 최소 블록으로 채운다 — 자동 빌드
-    # 에이전트가 새 표준 게이트에서 죽지 않게 하는 관문(모델 호출 없음, 기존 블록 보존).
+    # A card with no résumé (workforce) block gets filled with a deterministic
+    # minimal block — a gate that keeps an auto-built agent from dying at the
+    # new standard gate (no model call, preserves any existing block).
     from .networking.card_lint import ensure_workforce_block
 
     ensure_workforce_block(card)

--- a/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/workforce/execution.py
+++ b/claude/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/workforce/execution.py
@@ -43,12 +43,14 @@ _MAX_DIGEST_VALUE_NODES = 10_000
 def _is_valid_effort(value: Any) -> bool:
     """Same open vocabulary as model_allocation.normalize_effort.
 
-    2026-07-28 실측 드리프트: 이 파일의 예전 `_EFFORTS` 고정 집합은 "minimal"이 빠져
-    있었다 — model_allocation.py의 정본 튜플·MCP 스키마 어디에도 있는 값인데 여기서만
-    누락돼, 정상 해석된 "minimal" effort가 실행 영수증 검증에서 매번 거절됐다. 손으로
-    다시 베낀 닫힌 집합이 서로 어긋나는 바로 그 실패 양상이라, 값 하나를 추가하는 대신
-    검증 자체를 model_allocation의 단일 신택스 검사기로 옮겼다 — 다음에 provider가 새
-    리즌 레벨을 내놔도(예: "ultra") 이 파일을 다시 고칠 필요가 없다.
+    Measured drift, 2026-07-28: this file's old fixed `_EFFORTS` set was
+    missing "minimal" — a value present in model_allocation.py's canonical
+    tuple and in the MCP schema, but nowhere here, so a correctly resolved
+    "minimal" effort was rejected on every execution-receipt validation. That
+    is exactly the failure mode of a hand-copied closed set drifting out of
+    sync, so instead of adding one more value, validation itself moved onto
+    model_allocation's single syntax checker — the next time a provider ships
+    a new reason level (say, "ultra"), this file never needs touching again.
     """
     return value is None or (isinstance(value, str) and bool(EFFORT_TOKEN_RE.fullmatch(value)))
 

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/brief/shape.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/brief/shape.py
@@ -31,7 +31,7 @@ __all__ = ["classify_shape", "find_row_verdict", "SHAPES"]
 SHAPES = ("ledger", "verdict", "dossier", "computation", "blueprint", "rendition", "other")
 
 # A judgement property is one whose value space is a small closed set. The name is
-# irrelevant - `severity`, `status`, `verdict`, `등급` and `risk_tier` all qualify by
+# irrelevant - `severity`, `status`, `verdict`, `grade` and `risk_tier` all qualify by
 # having few allowed values, and a free-text field never does however it is named.
 _MAX_VERDICT_VALUES = 12
 

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/cli.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/cli.py
@@ -445,7 +445,7 @@ def main(argv: list[str] | None = None) -> int:
         "--scope",
         choices=["network", "cloud"],
         default="network",
-        help="network = public Hub marketplace; cloud = the signed-in owner's OWN cloud packages (보관함). cloud implies --hub-only (/hep-cloud).",
+        help="network = public Hub marketplace; cloud = the signed-in owner's OWN cloud packages. cloud implies --hub-only (/hep-cloud).",
     )
     route.add_argument(
         "--caller",
@@ -1014,8 +1014,8 @@ def main(argv: list[str] | None = None) -> int:
             # contracts, project-soul-memory.md, credentials/ and signing/
             # scaffolding — and rewrote .gitignore, with no consent and no notice.
             # Terminal already refuses to do this (it calls its own boundary with
-            # "read" permission and comments "context 명령은 프로젝트를 초기화하지
-            # 않는다"); Core was overriding that boundary from underneath.
+            # "read" permission and comments "the context command does not
+            # initialize a project"); Core was overriding that boundary from underneath.
             # Refresh an existing project, never conjure a new one.
             already_initialized = bool(
                 (Path(args.project).expanduser().resolve() / ".agentlas").is_dir()

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/interview/lenses.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/interview/lenses.py
@@ -15,28 +15,28 @@ from typing import Any
 
 LENS_GROUPS: dict[str, list[dict[str, str]]] = {
     "scope": [
-        {"id": "negative_space", "find": "언급되지 않은 인접 영역", "ko": "X는 언급 안 하셨는데, 의도적으로 뺀 건가요?", "en": "You didn't mention X — deliberately out of scope?"},
-        {"id": "minimum_version", "find": "과설계", "ko": "80%를 해결하는 가장 작은 버전은 뭔가요?", "en": "What is the smallest version that solves 80%?"},
-        {"id": "anti_scope", "find": "하면 안 되는 인접 작업 (anti_triggers 원천)", "ko": "비슷해 보여도 '이건 하면 안 된다'가 있다면요?", "en": "Anything that looks similar but must NOT be done?"},
-        {"id": "done_signal", "find": "끝의 정의", "ko": "뭘 보면 '됐다'고 판단하실 건가요?", "en": "What will you look at to call this done?"},
+        {"id": "negative_space", "find": "unmentioned adjacent area", "ko": "X는 언급 안 하셨는데, 의도적으로 뺀 건가요?", "en": "You didn't mention X — deliberately out of scope?"},
+        {"id": "minimum_version", "find": "over-engineering", "ko": "80%를 해결하는 가장 작은 버전은 뭔가요?", "en": "What is the smallest version that solves 80%?"},
+        {"id": "anti_scope", "find": "adjacent work that must not be done (source of anti_triggers)", "ko": "비슷해 보여도 '이건 하면 안 된다'가 있다면요?", "en": "Anything that looks similar but must NOT be done?"},
+        {"id": "done_signal", "find": "definition of done", "ko": "뭘 보면 '됐다'고 판단하실 건가요?", "en": "What will you look at to call this done?"},
     ],
     "system": [
-        {"id": "dependency_chain", "find": "숨은 결합", "ko": "X가 실패하면 같이 부서지는 게 뭔가요?", "en": "If X fails, what breaks with it?"},
-        {"id": "existing_assets", "find": "중복 구축", "ko": "이미 있는 Y를 확장할까요, 새로 만들까요?", "en": "Extend the existing Y, or build new?"},
-        {"id": "time_horizon", "find": "단기 해법의 부채", "ko": "3개월 뒤에도 이 결정이 유효한가요?", "en": "Will this decision still hold in 3 months?"},
-        {"id": "failure_mode", "find": "예외 경로", "ko": "가장 흔하게 잘못될 상황은 뭔가요?", "en": "What is the most common way this goes wrong?"},
+        {"id": "dependency_chain", "find": "hidden coupling", "ko": "X가 실패하면 같이 부서지는 게 뭔가요?", "en": "If X fails, what breaks with it?"},
+        {"id": "existing_assets", "find": "duplicate build", "ko": "이미 있는 Y를 확장할까요, 새로 만들까요?", "en": "Extend the existing Y, or build new?"},
+        {"id": "time_horizon", "find": "short-term-fix debt", "ko": "3개월 뒤에도 이 결정이 유효한가요?", "en": "Will this decision still hold in 3 months?"},
+        {"id": "failure_mode", "find": "exception path", "ko": "가장 흔하게 잘못될 상황은 뭔가요?", "en": "What is the most common way this goes wrong?"},
     ],
     "intent": [
-        {"id": "goal_of_goal", "find": "표층 요청 뒤 진짜 목표", "ko": "이게 되면 그다음에 뭘 하실 건가요?", "en": "Once this works, what happens next?"},
-        {"id": "audience", "find": "산출물의 소비자", "ko": "결과물을 누가 보나요/쓰나요?", "en": "Who consumes the output?"},
-        {"id": "rejected_alternatives", "find": "이미 시도한 것", "ko": "이미 해봤는데 안 됐던 방법이 있나요?", "en": "What have you already tried that didn't work?"},
-        {"id": "confidence_level", "find": "사실 vs 추정", "ko": "그건 확인된 사실인가요, 느낌인가요?", "en": "Is that a verified fact or a hunch?"},
+        {"id": "goal_of_goal", "find": "the real goal behind the surface request", "ko": "이게 되면 그다음에 뭘 하실 건가요?", "en": "Once this works, what happens next?"},
+        {"id": "audience", "find": "consumer of the output", "ko": "결과물을 누가 보나요/쓰나요?", "en": "Who consumes the output?"},
+        {"id": "rejected_alternatives", "find": "what's already been tried", "ko": "이미 해봤는데 안 됐던 방법이 있나요?", "en": "What have you already tried that didn't work?"},
+        {"id": "confidence_level", "find": "fact vs. assumption", "ko": "그건 확인된 사실인가요, 느낌인가요?", "en": "Is that a verified fact or a hunch?"},
     ],
     "challenge": [
-        {"id": "premortem", "find": "실패 시나리오", "ko": "6개월 뒤 실패했다고 치죠. 왜였을까요?", "en": "It failed six months from now — why?"},
-        {"id": "inversion", "find": "필수 회피 조건", "ko": "확실히 망치려면 뭘 하면 되나요?", "en": "What would guarantee failure?"},
-        {"id": "stop_criterion", "find": "손절 조건", "ko": "어떤 결과가 나오면 '그만두자'인가요?", "en": "What result would make you stop?"},
-        {"id": "forced_tradeoff", "find": "우선순위", "ko": "속도와 품질이 부딪히면 어느 쪽인가요?", "en": "When speed and quality collide, which wins?"},
+        {"id": "premortem", "find": "failure scenario", "ko": "6개월 뒤 실패했다고 치죠. 왜였을까요?", "en": "It failed six months from now — why?"},
+        {"id": "inversion", "find": "condition that must be avoided", "ko": "확실히 망치려면 뭘 하면 되나요?", "en": "What would guarantee failure?"},
+        {"id": "stop_criterion", "find": "cut-loss condition", "ko": "어떤 결과가 나오면 '그만두자'인가요?", "en": "What result would make you stop?"},
+        {"id": "forced_tradeoff", "find": "priority", "ko": "속도와 품질이 부딪히면 어느 쪽인가요?", "en": "When speed and quality collide, which wins?"},
     ],
 }
 

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/mcp_stdio.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/mcp_stdio.py
@@ -113,12 +113,15 @@ def _workforce_tool_contracts(*kinds: str) -> dict[str, dict[str, Any]]:
 
 
 def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
-    """검증 도구 전용 selection 스키마 — 순번 지정(candidateOrdinal)을 허용한다.
+    """Selection schema for verification tools only — allows specifying an
+    ordinal (candidateOrdinal) instead of a release ID.
 
-    canonical schemas/workforce-selection.schema.json 은 건드리지 않는다(허브·터미널
-    계약). 이 완화는 MCP 도구 입력에서만 유효하고, 핸들러가 순번을 저장된 명부로
-    정확한 agentReleaseId 로 해석한 뒤 canonical 형태로 심층 검증에 넘긴다.
-    48-hex ID 수기 복사는 실측된 오사 표면이다(2026-07-28 qwen 12회 중 1회 ID 절단).
+    Does not touch the canonical schemas/workforce-selection.schema.json (the
+    Hub/Terminal contract). This relaxation is valid only for MCP tool input;
+    the handler resolves the ordinal against the stored menu into the exact
+    agentReleaseId, then passes the canonical shape on to deep validation.
+    Hand-copying a 48-hex ID is a measured error surface (2026-07-28: 1 of 12
+    qwen attempts truncated the ID).
     """
     schema = _contract_property("selection", description)
     try:
@@ -128,7 +131,7 @@ def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
             "type": "integer",
             "minimum": 1,
             "maximum": 100,
-            "description": "명부에 부여된 후보 순번. agentReleaseId 대신 지정 가능 — 서버가 저장된 세션 명부에서 정확한 릴리스로 해석한다.",
+            "description": "The candidate's ordinal in the menu. May be given instead of agentReleaseId — the server resolves it to the exact release from the stored session menu.",
         }
     except (KeyError, TypeError):
         pass
@@ -137,25 +140,33 @@ def _selection_property_with_ordinal(description: str) -> dict[str, Any]:
 
 _MENU_AUDIT_FIELDS = ("qualificationEvidence", "packageHash", "contentDigest")
 
-# semanticSnapshot 안의 중량 칸. 카드가 문장을 통째로 artifact ID로 슬러그화해 담는
-# 자리라 후보 1명이 수십 개를 싣는데, 후보끼리 겹치지 않아 대조 자체가 불가능하다
-# (라이브 1슬롯 10후보 실측: produces 고유 365개 중 2명 이상 공유 1개=0%, consumes
-# 149개 중 0개). 같은 내용은 summaries가 한 문장으로 이미 갖고 있고, 실제 매칭은
-# Core가 세션 저장소 원본으로 수행한다. 따라서 명부에서는 개수만 남긴다.
+# Heavyweight fields inside semanticSnapshot. This is where a card stuffs a
+# whole sentence slugified into an artifact ID, so a single candidate can
+# carry dozens of them — and since candidates never overlap, comparing them is
+# not even possible in the first place (measured live, 1 slot with 10
+# candidates: 0% of 365 unique `produces` values shared by 2+ candidates, 0 of
+# 149 for `consumes`). The same content is already in the summaries as one
+# sentence, and actual matching is done by Core against the session store's
+# original data. So the menu keeps only the count.
 _MENU_SNAPSHOT_HEAVY_FIELDS = ("produces", "consumes")
 
 
 def _menu_projection(result: dict[str, Any]) -> dict[str, Any]:
-    """검색 응답을 결정용 요약 명부로 투영 — 드롭리스트 방식.
+    """Projects a search response into a decision-ready summary menu — a
+    drop-list approach.
 
-    "남길 것"을 열거하지 않고 감사 중량 필드만 뺀다: 에이전트 속성(카드 스키마)이
-    추가·개명돼도 새 필드는 자동 통과한다. 원본 전문은 Core 세션 저장소가 보유하며
-    검증·준비의 핀 대조는 저장소 원본으로 수행되므로 통제 손실이 없다.
-    실측(1슬롯 10후보): 41,216B → 약 22KB, 판단 실효 정보 손실 0.
+    Instead of enumerating what to keep, it drops only the audit-weight
+    fields: if an agent attribute (card schema) is added or renamed, the new
+    field passes through automatically. Core's session store holds the full
+    original text, and validation/preparation pin-matching is performed
+    against that original data, so no control is lost.
+    Measured (1 slot, 10 candidates): 41,216B -> about 22KB, zero loss of
+    decision-relevant information.
 
-    이 투영은 MCP 표면 전용이다. 터미널 러너는 semanticSnapshot 키 집합을 정확히
-    9개로 단언하므로(agentlas-workforce.cjs assertExactKeys), 같은 접기를 Core
-    공용 경로에 넣으면 그쪽이 candidate_set_invalid로 죽는다.
+    This projection is MCP-surface only. The Terminal runner asserts the
+    semanticSnapshot key set at exactly 9 keys
+    (agentlas-workforce.cjs assertExactKeys), so applying the same folding on
+    Core's shared path would make that side die with candidate_set_invalid.
     """
     projected = {key: value for key, value in result.items() if key != "candidateProvenance"}
     candidate_set = projected.get("candidateSet")
@@ -197,10 +208,11 @@ def _resolve_ordinal_assignments(
     selection: Mapping[str, Any],
     candidate_set: Mapping[str, Any],
 ) -> tuple[dict[str, Any] | None, str | None]:
-    """assignments의 candidateOrdinal을 저장된 명부로 정확한 릴리스 ID로 해석한다.
+    """Resolves each assignment's candidateOrdinal against the stored menu into an exact release ID.
 
-    반환: (canonical 형태로 정규화된 selection, None) 또는 (None, 거절 코드).
-    순번과 릴리스 ID를 동시에 줬는데 서로 다르면 조용히 한쪽을 고르지 않고 거절한다.
+    Returns: (selection normalized to canonical shape, None) or (None, a
+    refusal code). If both an ordinal and a release ID were given and they
+    disagree, this refuses rather than silently picking one.
     """
     slots_by_id: dict[str, list[Mapping[str, Any]]] = {}
     for slot in candidate_set.get("slots", []) or []:
@@ -490,7 +502,7 @@ TOOLS: list[dict[str, Any]] = [
     {
         "name": "hephaestus_cloud_search",
         "description": (
-            "Search ONLY the signed-in user's OWN Agentlas cloud packages (보관함) "
+            "Search ONLY the signed-in user's OWN Agentlas cloud packages "
             "and return a JSON decision with a receipt_id. This is the owner-scoped "
             "leg of the three-scope model: it skips local cards and the public "
             "marketplace, querying the Hub with the owner filter (cargo.*). The "
@@ -517,7 +529,7 @@ TOOLS: list[dict[str, Any]] = [
         "inputSchema": {
             "type": "object",
             "properties": {
-                "request": {"type": "string", "description": "Search request, for example: 시장 리포트 쓸 에이전트 찾아줘."},
+                "request": {"type": "string", "description": "Search request, for example: find an agent that can write a market report."},
                 "project_dir": {"type": "string", "description": "Project directory for context (default: cwd)."},
                 "limit": {"type": "integer", "description": "Candidates per section. Default 10."},
             },
@@ -1773,9 +1785,10 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                     "status": "error",
                     "error": getattr(exc, "code", "workforce_source_search_failed"),
                 }
-            # 기본은 결정용 요약 명부(투영). 원본 전문은 세션 저장소가 보유하므로
-            # 검증·준비의 핀 대조는 손실 없다. 레거시 전량-에코 흐름이 필요한
-            # 호출자만 fullDossier=true 로 원형을 받는다.
+            # Default is the decision-ready summary menu (projection). The
+            # session store holds the full original text, so validation/
+            # preparation pin-matching loses nothing. Only a caller that needs
+            # the legacy full-echo flow gets the original shape via fullDossier=true.
             if arguments.get("fullDossier") is True:
                 return search_result
             return _menu_projection(search_result)
@@ -1828,15 +1841,18 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                 stored_set = federation_result.get("candidateSet")
                 if isinstance(stored_set, Mapping):
                     candidate_set = stored_set
-            # 순번 지정 해석 — 48-hex ID 수기 복사 대신 명부 순번으로 후보를 지정할 수
-            # 있다. 여기서 저장된(또는 제출된) 명부로 정확한 릴리스 ID로 해석해
-            # canonical 형태로 만든 뒤에만 심층 검증에 넘긴다. 해석 실패는 조용한
-            # 대체 없이 거절한다.
+            # Ordinal resolution — lets a candidate be specified by its menu
+            # ordinal instead of hand-copying a 48-hex ID. Resolves it against
+            # the stored (or submitted) menu into the exact release ID, into
+            # canonical shape, and only then passes it on to deep validation.
+            # A resolution failure is refused, with no silent substitute.
             #
-            # prepare에도 같이 건다. validate 전용이던 동안, 순번으로 결재해 accepted를
-            # 받은 호출자가 같은 selection을 prepare에 넘기면 assignments[0].agentReleaseId
-            # 누락 + candidateOrdinal additionalProperties로 거절당했다(실측). validate는
-            # canonical 형태를 돌려주지 않으므로 호출자에게는 되돌릴 방법이 없었다.
+            # This is applied to prepare too. While it was validate-only, a
+            # caller who got an "accepted" verdict by ordinal, then passed the
+            # same selection to prepare, was refused with a missing
+            # assignments[0].agentReleaseId plus a candidateOrdinal
+            # additionalProperties error (measured). validate does not return
+            # the canonical shape, so the caller had no way to recover.
             if (
                 name in ("workforce.validate_selection", "workforce.prepare_execution")
                 and isinstance(selection, Mapping)
@@ -1969,14 +1985,17 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                             "repairable": True,
                             "hubCalls": 0,
                         }
-                    # prepareAttempt의 idempotencyKey는 payload 전체의 canonical
-                    # sha256이라 호스트 LLM이 손으로 만들 수 없는 값이다(터미널
-                    # 러너는 코드로 계산한다). MCP 호스트 경로에서는 미제공 시
-                    # Core가 같은 재료 — 정확한 WorkOrder/해석된 Selection의
-                    # canonical digest, federatedSelection의 수령 digest·소스 핀 —
-                    # 로 파생한다. occurrenceId를 selectionSessionId에서 파생하므로
-                    # 같은 세션의 재시도는 같은 키로 떨어져 멱등성이 유지된다.
-                    # 제공된 prepareAttempt는 그대로 대조 검증한다(약화 없음).
+                    # prepareAttempt's idempotencyKey is the canonical sha256
+                    # of the entire payload — a value a host LLM cannot
+                    # compute by hand (the Terminal runner computes it in
+                    # code). On the MCP host path, when it's not supplied,
+                    # Core derives it from the same material — the exact
+                    # WorkOrder / resolved Selection's canonical digest, plus
+                    # federatedSelection's received digest and source pins.
+                    # occurrenceId is derived from selectionSessionId, so a
+                    # retry within the same session lands on the same key and
+                    # idempotency is preserved. A supplied prepareAttempt is
+                    # matched and validated as-is (no weakening).
                     prepare_attempt = arguments.get("prepareAttempt")
                     if prepare_attempt is None:
                         from .workforce.prepare_cache import prepare_attempt_payload
@@ -2000,8 +2019,9 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
                                     ],
                                 )
                             except Exception:
-                                # 파생 실패는 조용한 대체 없이 기존 필수-인자
-                                # 검증 경로가 정직하게 거절하도록 남겨 둔다.
+                                # A derivation failure is left for the
+                                # existing required-argument validation path
+                                # to refuse honestly, with no silent substitute.
                                 prepare_attempt = None
                     service = WorkforceSourceService(session_store=store)
                     source_bundles = service.fetch_selected_runtime_bundles(
@@ -2162,7 +2182,7 @@ def _call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         return with_bootstrap(decision)
     if name == "hephaestus_cloud_search":
         # Owner-scoped: scope="cloud" implies hub_only inside route_request and
-        # queries only the signed-in user's OWN cloud packages (보관함).
+        # queries only the signed-in user's OWN cloud packages.
         # This routes, so it owes the same Work Brief contract as
         # hephaestus_route / `route --scope cloud`: same project_dir, same
         # brief, same reason on the way back when the brief cannot be used.

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/memory_contract.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/memory_contract.py
@@ -2,7 +2,7 @@
 memory rework, so the three surfaces (Desktop TS, Terminal CJS, hep Python) do
 not silently drift.
 
-Background: the memory logic lives in three places (CLAUDE.md "3제품 싱크" pattern,
+Background: the memory logic lives in three places (CLAUDE.md "3-product sync" pattern,
 extended here to the memory contract). The hep plugin is a lighter, per-slug
 implementation, but the *contracts* it produces on disk — the
 ``.agentlas/evolution-proposals.json`` shape, the ``context_source`` marker

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/memory_hook.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/memory_hook.py
@@ -212,10 +212,12 @@ def _source_path(item: dict[str, Any]) -> Path | None:
 def _source_staleness(item: dict[str, Any]) -> tuple[str | None, str | None]:
     """(inline age tag, staleness directive) for one cited source document.
 
-    2026-07-29 사고: 인덱스 문서가 12일 전에 동결됐는데 캡슐이 그 사실을 어디에도
-    표기하지 않아, 세션이 7/17 시점 사실을 현재로 단정했다. 나이는 캡슐 소비자가
-    추론할 수 없는 정보이므로 반드시 생산자가 라벨로 실어야 한다. Fail-open:
-    판별 불가능한 소스는 조용히 무표기(경고 오발보다 낫다).
+    2026-07-29 incident: the index document had been frozen for 12 days, but
+    the capsule carried no signal of that anywhere, so a session asserted
+    facts from 7/17 as current. Age is not something a capsule consumer can
+    infer, so the producer must always attach it as a label. Fail-open: a
+    source whose age can't be determined stays silently unlabeled rather than
+    risking a false staleness warning.
     """
 
     path = _source_path(item)
@@ -429,10 +431,12 @@ def build_capsule(
     if not lines and not evolution_line and not workforce_lines and not context_slice_line:
         return None, binding_root
     adapter_name, retrieval_status = _adapter_status(agent_result or project_result)
-    # 방출 계약: 판단은 세션 LLM이, 전달은 시스템이. .agentlas/pm은 이 백스톱
-    # 인덱스와 Desktop 인덱스가 모두 임베드하는 folder-shared 층이라, 여기 적힌
-    # 학습은 다음 세션부터 모든 호스트·제품의 recall로 돌아온다 (2026-07-29
-    # 실측: 실작업 학습이 이 층 밖에만 쌓여 소울·큐레이터가 굶었다).
+    # Emission contract: judgment is the session LLM's job, delivery is the
+    # system's. .agentlas/pm is a folder-shared layer that both this backstop
+    # index and the Desktop index embed, so a learning written here flows back
+    # into recall for every host and product starting the next session
+    # (measured 2026-07-29: real task learnings that only piled up outside
+    # this layer starved the Soul and Curator).
     emit_line = (
         "emit=after substantial work, record durable project learnings "
         "(fact/decision/procedure WITH evidence; never secrets or transcripts) as markdown in "

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/model_allocation.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/model_allocation.py
@@ -17,12 +17,15 @@ from typing import Any, Mapping
 
 SCHEMA_VERSION = "agentlas.model-allocation-decision.v1"
 TIERS = ("economy", "balanced", "frontier")
-# 알려진 값은 정책 상한과 비교할 "랭크 폴백"으로만 쓴다 — "유효한가" 게이트로 쓰지 않는다.
-# 2026-07-28 라이브 실측: codex debug models가 gpt-5.6-sol에서 "ultra"(자동 위임) 리즌
-# 레벨을 실제로 광고했다. 이 튜플로 게이트를 걸면 provider가 이미 출시한 값을 우리가
-# 스키마 검증 단계에서 조용히 거절한다(전체 decision이 invalid_effort로 폐기됨). 새 값이
-# 나올 때마다 이 튜플을 고치는 대신, 세션 인벤토리가 보고하는 모델 자체 순서(=능력 랭크,
-# provider 계약)를 신뢰하는 쪽으로 옮겼다 — 아래 normalize_effort/_bounded_effort 참고.
+# The known values are used only as a "rank fallback" to compare against a
+# policy ceiling — never as a validity gate. Measured live 2026-07-28: codex
+# debug models actually advertised an "ultra" (auto-delegate) reason level on
+# gpt-5.6-sol. Gating on this tuple would have us silently reject a value the
+# provider already shipped, at the schema-validation step (discarding the
+# whole decision as invalid_effort). Instead of patching this tuple every time
+# a new value appears, validation moved to trusting the model's own ordering
+# as reported by the session inventory (= capability rank, a provider
+# contract) — see normalize_effort/_bounded_effort below.
 EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 EFFORT_TOKEN_RE = re.compile(r"^[a-z][a-z0-9-]{0,23}$")
 PHASES = ("plan", "execute", "verify", "synthesize", "route", "clarify")
@@ -48,7 +51,7 @@ INVOCATION_STAGE_PHASES = {
     "clarify": "clarify",
 }
 TIER_RANK = {tier: index for index, tier in enumerate(TIERS)}
-# 알려진 값의 폴백 랭크만 — 미지의 값을 이 표로 거절하지 않는다(_bounded_effort 참고).
+# Fallback rank for known values only — an unknown value is never rejected by this table (see _bounded_effort).
 EFFORT_RANK = {effort: index for index, effort in enumerate(EFFORTS)}
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@-]{2,255}$")
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -126,9 +129,11 @@ def normalize_tier(value: Any) -> str | None:
 
 
 def normalize_effort(value: Any) -> str | None:
-    # 신택스만 검증한다 — 화이트리스트 존재는 게이트로 쓰지 않는다(위 EFFORTS 주석).
-    # 이 함수는 parent-AI가 요청한 값과, 세션 인벤토리가 보고한 모델 자체 지원 목록
-    # 양쪽에 다 쓰인다 — 열어두면 두 경로 모두에서 새 값이 조용히 안 드롭된다.
+    # Validates syntax only — the existence of a whitelist is not used as a
+    # gate (see the EFFORTS comment above). This function is used both for a
+    # value the parent AI requested and for the model's own supported-value
+    # list as reported by the session inventory — keeping it open means a new
+    # value never gets silently dropped on either path.
     normalized = _text(value).lower()
     return normalized if EFFORT_TOKEN_RE.fullmatch(normalized) else None
 
@@ -460,9 +465,10 @@ def _bounded_effort(requested: str, supported: list[str], max_effort: str) -> tu
     if eligible:
         resolved = max(eligible, key=lambda item: _effort_rank(item, supported))
     else:
-        # 요청/상한 어느 쪽과도 동시에 맞는 값이 없다 — 모델이 제공하는 가장 낮은
-        # 값으로 최대한 보수적으로 내려간다(원래 폴백과 동일, 상한을 우선시해
-        # 요청보다 위로 에스컬레이션하지 않는다).
+        # Nothing matches both the request and the ceiling at once — fall
+        # back as conservatively as possible, to the lowest value the model
+        # offers (same as the original fallback; the ceiling takes priority,
+        # so this never escalates above what was requested).
         resolved = min(supported, key=lambda item: _effort_rank(item, supported))
     return resolved, resolved != requested
 
@@ -523,12 +529,15 @@ def resolve_model_allocation(
     inventory = _normalize_inventory(raw_inventory)
     policy = dict(policy or {})
     escalation_request, escalation_issues = _validate_escalation(escalation)
-    # maxEscalations는 부모가 선언한 비용 상한이다. 상한은 "권한을 주는 값"이 아니라
-    # "권한을 제한하는 값"이므로, 관계없는 검증 이슈(unknown_fields 등)가 하나만 섞여도
-    # 상한 검사를 통째로 건너뛰면 안 된다. 예전에는 `and not issues` 때문에 무관한
-    # 필드 하나가 상한을 무력화해 maxEscalations=0인 결정도 frontier/xhigh로 승격됐다.
-    # decision이 존재하면 selection.maxEscalations는 항상 정규화되어 있고(불량/누락은
-    # 기본값 0) 따라서 이슈가 있는 결정일수록 더 보수적으로 막힌다 — fail-closed.
+    # maxEscalations is a cost ceiling the parent declared. A ceiling is a
+    # value that restricts authority, not one that grants it, so a single
+    # unrelated validation issue (unknown_fields, etc.) mixed in must never
+    # skip the ceiling check entirely. Previously, `and not issues` let one
+    # irrelevant field disable the ceiling, so even a maxEscalations=0
+    # decision could be escalated to frontier/xhigh. Whenever a decision
+    # exists, selection.maxEscalations is always normalized (a bad or missing
+    # value defaults to 0), so a decision with issues is blocked more
+    # conservatively, not less — fail-closed.
     if (
         escalation_request is not None
         and decision is not None
@@ -554,8 +563,9 @@ def resolve_model_allocation(
         or "orchestrator"
     )
     if escalation_request is not None:
-        # 승격은 단계→역할 기본 매핑에 대한 유일한 허용 예외다. worker 단계의
-        # 마지막 재시도 한 번만 orchestrator 역할 정책으로 해석한다.
+        # Escalation is the one allowed exception to the default stage->role
+        # mapping. Only the last retry of a worker stage is interpreted under
+        # the orchestrator role policy.
         resolved_role = "orchestrator"
     role_policy, inherited_role_policy = _policy_for_role(policy, resolved_role)
     current_model_id = _text(role_policy.get("currentModelId"))
@@ -613,8 +623,9 @@ def resolve_model_allocation(
         else:
             reasons.append("pinned_model_unavailable_or_incompatible")
 
-    # 승격된 재시도는 worker 단계용 parent decision이 아니라 orchestrator 역할
-    # 정책이 지배한다 — decision은 맥락으로만 남고 모델 선택에는 쓰지 않는다.
+    # An escalated retry is governed by the orchestrator role policy, not the
+    # worker stage's parent decision — the decision stays only as context and
+    # is not used for model selection.
     if selected is None and decision is not None and not issues and escalation_request is None:
         requested_tier = decision["selection"]["tier"]
         if TIER_RANK[requested_tier] > TIER_RANK[max_tier]:
@@ -666,14 +677,17 @@ def resolve_model_allocation(
                 reasons.append("parent_exact_model_required_for_ambiguous_inventory")
 
     if selected is None and escalation_request is not None:
-        # 승격 재시도는 위 블록에서 parent decision을 의도적으로 건너뛴다. 그래서
-        # 운영자 핀(pinnedModelId)이 없으면 여기까지 어떤 분기도 selected를 채우지
-        # 못했고, 유일하게 허용된 재시도가 항상 unresolved로 죽었다 — 핀은 선택
-        # 사항이므로 핀을 두지 않은 모든 운영자에게 승격 계약 자체가 사문화된다.
-        # 핀이 없을 때도 orchestrator 역할 정책만으로 결정적으로 고른다: maxTier
-        # 이하 후보 중 최상위 tier를 쓰고("약모델 실패 → 강모델 승격"), 동률이면
-        # 역할의 현재 모델로 가른다. 정책 상한을 넘기지 않으므로 승격이 비용
-        # 가드레일을 뚫는 경로가 되지는 않는다.
+        # An escalation retry deliberately skips the parent decision in the
+        # block above. So without an operator pin (pinnedModelId), no branch
+        # up to this point had filled `selected`, and the one allowed retry
+        # always died as unresolved — since a pin is optional, this silently
+        # voided the escalation contract for every operator who didn't set
+        # one. Even with no pin, choose deterministically from the
+        # orchestrator role policy alone: use the highest tier among
+        # candidates at or below maxTier ("weak model failed -> escalate to a
+        # strong one"), breaking ties with the role's current model. This
+        # never exceeds the policy ceiling, so escalation is never a path
+        # around the cost guardrail.
         allowed = [
             item
             for item in compatible_inventory
@@ -702,9 +716,10 @@ def resolve_model_allocation(
         if decision is None or issues:
             reasons.append("parent_decision_missing_or_invalid")
         elif escalation_request is not None:
-            # 승격 경로는 parent decision의 모델을 요청하지 않는다. 여기서
-            # no_compatible_requested_model을 남기면 살아 있는 호환 모델을 두고도
-            # "요청 모델이 비호환"이라는 거짓 사유를 보고하게 된다.
+            # The escalation path never requests the parent decision's model.
+            # Recording no_compatible_requested_model here would report a
+            # false "the requested model is incompatible" reason even though
+            # a compatible model was actually available.
             reasons.append("escalation_target_unavailable")
         else:
             reasons.append("no_compatible_requested_model")
@@ -719,8 +734,10 @@ def resolve_model_allocation(
     risk = decision["features"]["risk"] if decision else "unknown"
     parent_reason_codes = list(decision["reasonCodes"]) if decision else []
     if escalation_request is None and "escalated-after-failure" in parent_reason_codes:
-        # 승격 없이 승격 사유코드만 오는 것은 계약 위반이다 — 조용히 통과시키면
-        # 소비자가 승격 필드 없는 승격을 믿게 된다. 사유코드를 떼고 이슈로 남긴다.
+        # An escalation reason code arriving with no actual escalation is a
+        # contract violation — passing it through silently would let a
+        # consumer believe an escalation happened with no escalation field.
+        # Strip the reason code and record it as an issue instead.
         escalation_issues.append("escalation_reason_code_without_escalation")
         parent_reason_codes = [code for code in parent_reason_codes if code != "escalated-after-failure"]
     if escalation_request is not None:

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/card_lint.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/card_lint.py
@@ -196,7 +196,7 @@ def lint_card(card: dict[str, Any]) -> dict[str, Any]:
     if bench_cases < 10:
         ready_blockers.append(f"needs >=10 benchmark cases (has {bench_cases})")
 
-    # 이력서(workforce) block — the hub standard résumé the Workforce search
+    # résumé (workforce) block — the hub standard résumé the Workforce search
     # matches on. Measured over the live catalog (2026-07-27) sellers declared
     # roles/modalities on 0 of 250 cards, so every WorkOrder using those fields
     # excluded the whole catalog. Built packages must ship the block filled;
@@ -205,9 +205,11 @@ def lint_card(card: dict[str, Any]) -> dict[str, Any]:
     # ontology snapshot supplies aliases/relations, not a profession allowlist.
     workforce = card.get("workforce")
     if not isinstance(workforce, dict):
-        # 자동 빌드 파이프라인(스톰 워커, 변환 패키징)은 블록을 손으로 못 쓴다 —
-        # 결정적 파생이 가능하므로 린트는 경고만 남기고, 하드 게이트는 서버
-        # 등록 경계(workforce_resume_incomplete)와 업로드 관문의 자동 채움이 맡는다.
+        # An automated build pipeline (Stormbreaker workers, conversion
+        # packaging) cannot hand-write this block. Since a deterministic
+        # derivation is possible, lint only warns — the hard gate is left to
+        # the server registration boundary (workforce_resume_incomplete) and
+        # the upload gate's auto-fill.
         derived = ensure_workforce_block(dict(card))
         workforce = derived["workforce"]
         warnings.append(

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/card_store.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/card_store.py
@@ -44,8 +44,9 @@ def save_card(home: Path, card: dict[str, Any]) -> Path:
     card["updated_at"] = card.get("updated_at") or utc_now()
     target = card_path(home, card)
     atomic_write_json(target, card)
-    # 데스크탑 핸드오프 — trusted local 등록은 수동 임포트 없이 Agentlas Desktop
-    # 라이브러리에 도달해야 한다(자격 미달/실패는 조용히 무시, 등록을 깨지 않음).
+    # Desktop handoff — a trusted local registration must reach the Agentlas
+    # Desktop library without a manual import (a failure or unmet requirement
+    # is silently ignored here rather than breaking the registration).
     enqueue_desktop_sync(home, card)
     return target
 

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/desktop_sync.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/desktop_sync.py
@@ -29,7 +29,8 @@ from .bootstrap import atomic_write_json, read_json, utc_now
 PENDING_DIR = "desktop-sync/pending"
 DONE_DIR = "desktop-sync/done"
 
-# 패키지 실체 확인용 마커 — 이 중 하나는 있어야 임포트 가능한 폴더로 본다.
+# Markers that confirm a real package — a folder must have at least one of
+# these to be treated as importable.
 _PACKAGE_MARKERS = ("agentlas.json", "AGENT.md", "AGENTS.md", "TEAM.md", "CLAUDE.md")
 
 
@@ -45,7 +46,8 @@ def _package_ref(card: dict[str, Any]) -> Path | None:
     if not raw:
         return None
     ref = Path(raw)
-    # reindex가 상대경로('.')를 남긴 이력이 있다 — 절대경로 + 실존 + 패키지 마커까지 요구.
+    # reindex has a history of leaving a relative path ('.') behind — require
+    # an absolute path, that it actually exists, and a package marker too.
     if not ref.is_absolute() or not ref.is_dir():
         return None
     if not any((ref / marker).is_file() for marker in _PACKAGE_MARKERS):

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/goal_loop.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/goal_loop.py
@@ -9,13 +9,13 @@ repetition is the point, not a defect.
 This module adds the missing half: a controller that auto-constructs a loop for a
 task and drives it **until the goal verifies**, while staying stable —
 
-- **don't break (안 끊기게):** a transient iteration failure does not kill the loop.
+- **don't break:** a transient iteration failure does not kill the loop.
   It is journaled and retried with backoff, up to `max_consecutive_failures` in a
   row. Only a genuine streak of hard failures stops the run.
 - **don't run away:** a hard `max_iterations` ceiling, plus stall detection —
   if `stall_window` consecutive iterations make no new progress, the loop stops as
   `stalled` instead of spinning forever. Progress is measured, not assumed.
-- **keep the goal until done (될때까지 목표 유지):** the loop only reports
+- **keep the goal until done:** the loop only reports
   `reached_goal` when the goal predicate verifies; it never claims success on a
   bare "it ran."
 - **survive a hard stop:** every iteration is a Run Journal step, so a killed loop

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/router.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/router.py
@@ -636,14 +636,17 @@ def _hub_query_has_fitting_borrowable(query_tokens: list[str], results: list[dic
     )
 
 
-# 일반적인 빌드/기획 동사는 "이 에이전트를 지목했다"고 볼 만큼 특이하지 않으므로 제외 —
-# 진짜 역할 단어("웹마스터", "카피라이터")로만 매칭한다.
+# Generic build/planning verbs are excluded — they aren't distinctive enough
+# to count as "this agent was explicitly named." Only real role words
+# ("webmaster", "copywriter") count as a match.
 _GENERIC_ROLE_TOKENS = {
     "기획", "제작", "개발", "구현", "빌드", "만들", "작업", "불러", "불러서", "해줘", "해",
     "팀", "웹", "앱", "사이트", "페이지", "랜딩", "랜딩페이지", "에이전트", "등",
     "agent", "team", "build", "make", "plan", "create", "page", "landing", "web", "app", "site",
-    # 제품/브랜드 주제어 — 요청의 '주제'이지 에이전트 '지목'이 아니다. 이게 없으면 "Agentlas에
-    # 대해서 글 써줘"에서 이름에 agentlas가 든 후보(PRD 메이커 등)를 "지목됨"으로 오판해 다 빌려온다.
+    # Product/brand topic words — these are the request's "topic," not an
+    # agent being "named." Without this, "write something about Agentlas"
+    # would misjudge any candidate with "agentlas" in its name (a PRD maker,
+    # etc.) as "named" and borrow all of them.
     "agentlas", "hephaestus", "oberon", "대해서", "대한", "관련",
 }
 
@@ -719,9 +722,11 @@ def _byom_execution_plan(
                 )
     else:
         borrowable = [item for item in (results or []) if _is_borrowable(item)]
-        # 사용자가 에이전트를 명시적으로 지목했으면("웹마스터 카피라이터 불러서") 전부 빌려온다 —
-        # 다중 역할 요청을 최상위 후보 1개로 축소하지 않는다(Hub가 오프도메인 에이전트를 명시된
-        # 에이전트보다 높게 랭크할 수 있으므로 명시 지목을 우선).
+        # If the user explicitly named agents (e.g. "call the webmaster and
+        # the copywriter"), borrow all of them — a multi-role request is never
+        # reduced to a single top candidate (the Hub can rank an off-domain
+        # agent above one that was explicitly named, so an explicit name
+        # takes priority).
         named = _explicitly_named_borrowables(query, borrowable)
         if named:
             for cand in named[:5]:
@@ -741,10 +746,12 @@ def _byom_execution_plan(
     # returning a task_force with execution=null.
     if not recommended and not stages:
         return None
-    # 명시 지목이 2개+면 이건 "여러 전문가가 협업하는 하나의 산출물" — 실행 모델이 임시
-    # 오케스트레이터 역할(plan→dispatch→synthesize)을 맡도록 directive를 전환한다. CLI에는
-    # 별도 오케스트레이터 세션이 없으므로(hep-storm --executor-command 없이는) 베이스 모델이
-    # 매니저가 되는 게 현실적 경로다.
+    # Two or more explicit names means this is "one deliverable from several
+    # specialists collaborating" — switch the directive so the execution
+    # model takes on a temporary orchestrator role (plan -> dispatch ->
+    # synthesize). The CLI has no separate orchestrator session (short of
+    # hep-storm --executor-command), so the base model becoming the manager
+    # is the realistic path.
     core_stages = [
         str(stage.get("stage"))
         for stage in (stages or [])
@@ -792,7 +799,7 @@ def _byom_execution_plan(
         )
     return {
         "mode": "byom_local_grounded",
-        # 다중 명시 지목이면 실행 모델이 매니저 역할을 맡는다는 신호.
+        # Multiple explicit names is the signal for the execution model to take on the manager role.
         "formation": "temporary_orchestrator" if multi else "single_specialist",
         "primary_agent": primary,
         "recommended_agents": recommended,
@@ -993,7 +1000,7 @@ def route_request(
 
     # Three-scope command model (docs/hephaestus-network-2.0.md):
     #   scope="cloud"   -> /hep-cloud: search ONLY the signed-in user's
-    #                     OWN cloud packages (보관함). Owner-scoped Hub query,
+    #                     OWN cloud packages. Owner-scoped Hub query,
     #                     implies hub_only (skip local + public marketplace).
     #   scope="network" -> /hep-network: search Cloud > Bookmark > public Hub
     #                     in that order. Used with hub_only by the network command.
@@ -1164,7 +1171,7 @@ def route_request(
         )
 
     if hub_only:
-        # The owner cloud (보관함) and the public marketplace share this
+        # The owner cloud and the public marketplace share this
         # Hub-only flow; the only difference is the scope passed to the Hub and
         # the receipt/reason tag, so /hep-cloud and /hep-network
         # stay one code path with two scopes.

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/router_agent_call.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/networking/router_agent_call.py
@@ -53,9 +53,11 @@ def router_escalation(
         return None
     action = str(result.get("action") or "")
     hub_results = ((result.get("hub") or {}).get("results")) if isinstance(result.get("hub"), dict) else None
-    # hub_candidates 는 "후보를 찾았다"는 이유로 렉시컬 top-1 을 그대로 primary 로 밀지만,
-    # 렉시컬 점수는 브랜드/주제어에 쉽게 휘둘려 오선택한다("쓰레드 글 써줘"→PRD 메이커). 후보가 2개 이상이면
-    # 호스트 LLM 라우터에 넘겨 '의도 적합도'로 재정렬하게 한다(키워드 나열이 아니라 의미 기반 선택).
+    # hub_candidates pushes the lexical top-1 straight through as primary just
+    # because "a candidate was found," but a lexical score is easily thrown off
+    # by a brand name or topic word and mis-selects (e.g. "write a Threads
+    # post" -> a PRD maker). With two or more candidates, hand off to the host
+    # LLM router to re-rank by actual intent fit instead of keyword overlap.
     hub_multi = (
         action == "hub_candidates"
         and isinstance(hub_results, list)

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/package_contract.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/package_contract.py
@@ -371,7 +371,7 @@ def _verify_artifact(workspace: Path, artifact: dict[str, Any], base: Path) -> d
             source["ref"] = str(workspace)
         try:
             lint = lint_card({**doc, "source": source})
-        except Exception as err:  # 카드가 어떤 모양이든 게이트는 크래시하지 않는다
+        except Exception as err:  # the gate must not crash no matter what shape the card is
             lint = {"errors": [f"lint crashed on malformed card: {err}"], "ready_blockers": []}
         report["routing_lint"] = lint
         problems.extend(f"routing-card: {err}" for err in lint.get("errors", []))

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/project_bootstrap.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/project_bootstrap.py
@@ -1358,10 +1358,12 @@ def _bounded_project_map(project_map: dict[str, Any]) -> tuple[str, int]:
             key=lambda key: (-int(ref_counts.get(key) or 0), key),
         )
         original_refs = len(ordered)
-        # 바이트 예산이 계약이고 "최소 1,000개 유지"는 휴리스틱이다. 파일당 심볼
-        # 상한을 올린 뒤로는 이 바닥이 작은 예산과 교착해 맵 전체를 잃게 했다
-        # (예산 초과 = OSError = 맵 없음). ordered는 참조 빈도순이므로 바닥을
-        # 1로 내려도 가장 뜨거운 심볼부터 예산이 허락하는 만큼 남는다.
+        # The byte budget is the contract; "keep at least 1,000" is only a
+        # heuristic. Since the per-file symbol cap was raised, that floor has
+        # deadlocked against a small budget and lost the whole map (budget
+        # exceeded = OSError = no map). ordered is sorted by reference
+        # frequency, so lowering the floor to 1 still keeps as many of the
+        # hottest symbols as the budget allows.
         while len(raw.encode("utf-8")) > MAX_CODE_MAP_BYTES and len(ordered) > 1:
             ordered = ordered[: max(1, len(ordered) // 2)]
             allowed = set(ordered)
@@ -1374,9 +1376,10 @@ def _bounded_project_map(project_map: dict[str, Any]) -> tuple[str, int]:
             project_map["stats"]["outputTruncated"] = True
             project_map["stats"]["refIndexSymbolsOmitted"] = original_refs - len(allowed)
             raw = json.dumps(project_map, ensure_ascii=False, separators=(",", ":")) + "\n"
-    # 파일당 심볼 상한을 올린 뒤로는 defIndex/topSymbols 단독으로도 작은 예산을
-    # 넘을 수 있다. 사다리 뒤쪽에 두어 정의 색인이 가장 오래 살아남게 하되,
-    # 바이트 예산이 최종 계약이므로 여기서도 수렴할 때까지 절반씩 줄인다.
+    # Since the per-file symbol cap was raised, defIndex/topSymbols alone can
+    # now exceed a small budget too. This step comes last in the ladder so the
+    # definition index survives longest, but the byte budget is still the
+    # final contract, so keep halving until it converges here too.
     if len(raw.encode("utf-8")) > MAX_CODE_MAP_BYTES and isinstance(project_map.get("defIndex"), dict) and project_map["defIndex"]:
         def_counts = project_map.get("refCount") if isinstance(project_map.get("refCount"), dict) else {}
         ordered_defs = sorted(

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/project_index_backstop.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/project_index_backstop.py
@@ -156,9 +156,11 @@ def _read_bounded_text(path: Path, max_bytes: int) -> str | None:
 def _discover_pm_files(project_root: Path) -> list[tuple[str, str]]:
     """Bounded pm documents, session learnings first and newest first.
 
-    2026-07-29 실측: 이름순·루트우선 순회에서는 7월 중순의 대형 HANDOFF 문서가
-    48K자 예산을 먼저 소진해, 방금 기록한 `learnings/` 학습이 인덱스에 한 글자도
-    못 실렸다. recall 가치는 최신·학습 문서가 가장 크므로 그 순서로 예산을 쓴다.
+    Measured 2026-07-29: a name-ordered, root-first traversal let a large
+    mid-July HANDOFF document exhaust the 48K-character budget first, so a
+    learning recorded moments earlier never made it into the index at all.
+    Recall value is highest for the newest and the learnings documents, so
+    the budget is spent in that order.
     """
 
     pm_root = project_root / ".agentlas" / PM_DIR

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/agentlas_browser_launcher.mjs
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/research/adapters/agentlas_browser_launcher.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-// Agentlas Browser (CDP) — 범용 엔진. 실제 로그인 Chrome 전용 프로필을 원격 디버깅 포트로 띄우고
-// @playwright/mcp 를 CDP 로 붙여 MCP 브라우저 도구를 제공한다. 이 프로세스가 client ↔ @playwright/mcp
-// 사이를 stdio 로 프록시하며 (1) 되돌릴 수 없는 행동 승인 게이트, (2) learn-and-replay 스킬 레이어를 얹는다.
-// 의존성 0(순수 node). 개인 데이터는 로컬에서만 사용, 어디로도 전송하지 않는다.
+// Agentlas Browser (CDP) — general-purpose engine. Launches the real, already
+// logged-in Chrome profile with a remote debugging port, then attaches
+// @playwright/mcp over CDP to provide MCP browser tools. This process proxies
+// stdio between the client and @playwright/mcp, layering on (1) an approval
+// gate for irreversible actions, and (2) a learn-and-replay skill layer.
+// Zero dependencies (pure node). Personal data is used locally only and never sent anywhere.
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -86,7 +88,7 @@ async function ensureChrome() {
   throw new Error('Chrome CDP port did not open: ' + PORT);
 }
 
-// ── 승인 게이트 ──────────────────────────────────────────────────
+// ── approval gate ──────────────────────────────────────────────────
 // CONTRACT (fail-closed): the regexes below only LABEL the approval kind —
 // they never make the final "no gate needed" decision for a commit-like
 // action. A click/keypress/upload that submits, pays, sends, or deletes but
@@ -146,8 +148,8 @@ function requestApproval(site, actionType, summary) {
   });
 }
 
-// ── learn-and-replay 스킬 레이어 ─────────────────────────────────
-// 재생/기록 대상 액션 툴(읽기 전용 snapshot/screenshot 등은 제외).
+// ── learn-and-replay skill layer ─────────────────────────────────
+// Action tools eligible for recording/replay (excludes read-only ones like snapshot/screenshot).
 const RECORDABLE = new Set(['browser_navigate', 'browser_navigate_back', 'browser_click', 'browser_type', 'browser_fill', 'browser_fill_form', 'browser_select_option', 'browser_press_key', 'browser_hover', 'browser_file_upload', 'browser_drag']);
 const SKILL_TOOLS = [
   { name: 'browser_skill_list', description: 'List saved Agentlas browser skills (learned action sequences).', inputSchema: { type: 'object', properties: {} } },
@@ -171,15 +173,15 @@ async function main() {
   child.on('error', (e) => { log('failed to start @playwright/mcp', String(e)); process.exit(1); });
   child.on('exit', (code) => process.exit(code == null ? 0 : code));
 
-  const recording = [];            // 이 세션에서 성공한 액션 시퀀스
-  const pending = new Map();       // client 원본 tools/call: id -> {name, args}
-  const waiters = new Map();       // 내부(replay) tools/call: id -> resolve
+  const recording = [];            // sequence of actions that succeeded in this session
+  const pending = new Map();       // client's original tools/call: id -> {name, args}
+  const waiters = new Map();       // internal (replay) tools/call: id -> resolve
   let currentUrl = '';
   let internalSeq = 0;
   const writeClient = (obj) => { try { process.stdout.write(JSON.stringify(obj) + '\n'); } catch (e) {} };
   const forwardRaw = (line) => { try { child.stdin.write(line + '\n'); } catch (e) {} };
 
-  // 승인 게이트 통과 여부 판정(공유). 통과=null, 거부=사유문자열.
+  // Shared approval-gate verdict. Pass = null, refuse = reason string.
   const gate = async (name, args, preJudgedKind) => {
     const actionType = classifyAction(name, args, preJudgedKind);
     if (!actionType) return null;
@@ -191,7 +193,7 @@ async function main() {
     return decision === 'approved' ? null : actionType;
   };
 
-  // 내부에서 child 에 tools/call 을 보내고 응답을 받는다(replay 용).
+  // Internally sends a tools/call to the child and gets the response (for replay).
   const callChild = (name, args) => new Promise((resolve) => {
     const id = 'agx-' + (++internalSeq);
     waiters.set(id, resolve);
@@ -214,14 +216,14 @@ async function main() {
     writeClient({ jsonrpc: '2.0', id: replyId, result: { content: [{ type: 'text', text: 'Replayed skill "' + name + '" (' + (skill.steps || []).length + ' steps):\n' + results.join('\n') }] } });
   };
 
-  // client → child 방향
+  // client -> child direction
   const handleClientLine = (line) => {
     if (!line.trim()) { forwardRaw(line); return; }
     let msg; try { msg = JSON.parse(line); } catch (e) { forwardRaw(line); return; }
     if (msg && msg.method === 'tools/call' && msg.params) {
       const name = msg.params.name || '';
       const args = msg.params.arguments || {};
-      // 스킬 툴은 로컬 처리(child 로 안 보냄).
+      // Skill tools are handled locally (not sent to the child).
       if (name === 'browser_skill_list') { writeClient({ jsonrpc: '2.0', id: msg.id, result: { content: [{ type: 'text', text: JSON.stringify(listSkills()) }] } }); return; }
       if (name === 'browser_skill_save') {
         try { const doc = saveSkill(args.name, recording.slice(), args.description); writeClient({ jsonrpc: '2.0', id: msg.id, result: { content: [{ type: 'text', text: 'Saved skill "' + doc.name + '" with ' + doc.steps.length + ' steps → ' + skillPath(doc.name) }] } }); }
@@ -229,7 +231,7 @@ async function main() {
         return;
       }
       if (name === 'browser_skill_replay') { doReplay(args.name, msg.id); return; }
-      // 일반 액션: 승인 게이트 + 기록. 부모가 _meta 로 사전판정을 보냈으면 그 판정이 우선.
+      // Ordinary action: approval gate + record. If the parent sent a pre-judged verdict via _meta, that verdict wins.
       if (name === 'browser_navigate' && args.url) currentUrl = String(args.url);
       const preJudgedKind = (msg.params._meta || {})['agentlas/actionKind'];
       const actionType = classifyAction(name, args, preJudgedKind);
@@ -246,19 +248,19 @@ async function main() {
     forwardRaw(line);
   };
 
-  // child → client 방향 (응답 가로채기: replay waiter / 기록 / tools/list 주입)
+  // child -> client direction (intercepts responses: replay waiter / recording / tools/list injection)
   const handleChildLine = (line) => {
     if (!line.trim()) { process.stdout.write(line + '\n'); return; }
     let msg; try { msg = JSON.parse(line); } catch (e) { process.stdout.write(line + '\n'); return; }
-    // 내부 replay 응답 → waiter 로, client 로는 안 보냄.
+    // An internal replay response goes to the waiter, never to the client.
     if (msg && typeof msg.id === 'string' && waiters.has(msg.id)) { const r = waiters.get(msg.id); waiters.delete(msg.id); r(msg); return; }
-    // client 원본 액션 응답 → 성공 시 기록.
+    // Response to the client's original action -> record it on success.
     if (msg && msg.id != null && pending.has(msg.id)) {
       const call = pending.get(msg.id); pending.delete(msg.id);
       const isErr = msg.result && msg.result.isError;
       if (!isErr && !msg.error) recording.push(call);
     }
-    // tools/list 응답 → 스킬 툴 주입.
+    // tools/list response -> inject skill tools.
     if (msg && msg.result && Array.isArray(msg.result.tools)) {
       const have = new Set(msg.result.tools.map((t) => t.name));
       for (const st of SKILL_TOOLS) if (!have.has(st.name)) msg.result.tools.push(st);

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/update.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/update.py
@@ -37,8 +37,9 @@ HEALTHCHECK_TIMEOUT_SECONDS = 15
 MEMORY_HOOK_SYNC_TIMEOUT_SECONDS = 30
 MAX_RUNTIME_ARCHIVE_BYTES = 256 * 1024 * 1024
 # schemas/ carries the Workforce/Network contract files (workforce-work-order
-# 등). 2026-07-16 실측: 릴리스 아카이브에는 포함·강제되는데 이 목록에 없어서
-# 설치본에서만 통째로 유실 → 관리형 런타임의 hep-network가 스키마 결손으로 정지.
+# and others). Measured 2026-07-16: the release archive includes and enforces
+# this, but it was missing from this list, so it was lost entirely from
+# installs — a managed runtime's hep-network then stopped on a missing schema.
 RUNTIME_DIRS = ("bin", "agentlas_cloud", "career_graph", "ontology", "templates")
 RUNTIME_OPTIONAL_DIRS = ("schemas",)
 RUNTIME_FILES = ("package-contract.json",)
@@ -531,8 +532,8 @@ def fetch_latest_release(force: bool = False, ttl_seconds: int = DEFAULT_TTL_SEC
         # The TTL cache is an optimization, never part of the answer. Host
         # sandboxes (Claude Code, Codex, Cursor, ...) deny writes outside the
         # workspace, and a denied cache write must not discard a release fetch
-        # that already succeeded — 2026-07-29 실측: 이 쓰기가 샌드박스에서
-        # hep-update --check까지 통째로 죽이고 있었다.
+        # that already succeeded — measured 2026-07-29: this write was killing
+        # hep-update --check entirely inside a sandbox.
         pass
     return release
 

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/upload.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/upload.py
@@ -517,10 +517,12 @@ def register_package(
                     raise UploadError(
                         f"Agentlas Cloud registration failed HTTP {retry_exc.code} after precondition retry: {retry_detail}"
                     ) from retry_exc
-        # BYOM 반복 교정 루프의 CLI 절반: 서버는 업로드 중 플랫폼 LLM을 부르지 않고
-        # 불일치 목록 + 핀 온톨로지 메뉴를 돌려준다. 이 메시지를 읽는 것은 업로드를
-        # 실행 중인 제출자의 자기 모델이므로, 800자 캡에 가이드가 잘리면 루프가
-        # 죽는다 — 전문을 구조화해 그대로 전달한다.
+        # The CLI half of the BYOM repair-retry loop: the server never calls a
+        # platform LLM during upload, it returns a mismatch list plus the
+        # pinned ontology menu. The one reading this message is the
+        # submitter's own model driving the upload, so truncating the
+        # guidance at an 800-char cap would kill the loop — pass the full,
+        # structured message through untouched.
         if exc.code == 422:
             try:
                 body = json.loads(detail)
@@ -567,8 +569,9 @@ def refresh_routing_card_metadata(base: Path) -> dict[str, Any]:
         return {"updated": False, "reason": "invalid_routing_card"}
 
     before = json.dumps(card, sort_keys=True, ensure_ascii=False)
-    # 이력서(workforce) 블록이 없는 카드는 결정적 최소 블록으로 채운다 — 자동 빌드
-    # 에이전트가 새 표준 게이트에서 죽지 않게 하는 관문(모델 호출 없음, 기존 블록 보존).
+    # A card with no résumé (workforce) block gets filled with a deterministic
+    # minimal block — a gate that keeps an auto-built agent from dying at the
+    # new standard gate (no model call, preserves any existing block).
     from .networking.card_lint import ensure_workforce_block
 
     ensure_workforce_block(card)

--- a/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/workforce/execution.py
+++ b/codex/plugins/agentlas-core-engine-meta-agent/agentlas_cloud/workforce/execution.py
@@ -43,12 +43,14 @@ _MAX_DIGEST_VALUE_NODES = 10_000
 def _is_valid_effort(value: Any) -> bool:
     """Same open vocabulary as model_allocation.normalize_effort.
 
-    2026-07-28 실측 드리프트: 이 파일의 예전 `_EFFORTS` 고정 집합은 "minimal"이 빠져
-    있었다 — model_allocation.py의 정본 튜플·MCP 스키마 어디에도 있는 값인데 여기서만
-    누락돼, 정상 해석된 "minimal" effort가 실행 영수증 검증에서 매번 거절됐다. 손으로
-    다시 베낀 닫힌 집합이 서로 어긋나는 바로 그 실패 양상이라, 값 하나를 추가하는 대신
-    검증 자체를 model_allocation의 단일 신택스 검사기로 옮겼다 — 다음에 provider가 새
-    리즌 레벨을 내놔도(예: "ultra") 이 파일을 다시 고칠 필요가 없다.
+    Measured drift, 2026-07-28: this file's old fixed `_EFFORTS` set was
+    missing "minimal" — a value present in model_allocation.py's canonical
+    tuple and in the MCP schema, but nowhere here, so a correctly resolved
+    "minimal" effort was rejected on every execution-receipt validation. That
+    is exactly the failure mode of a hand-copied closed set drifting out of
+    sync, so instead of adding one more value, validation itself moved onto
+    model_allocation's single syntax checker — the next time a provider ships
+    a new reason level (say, "ultra"), this file never needs touching again.
     """
     return value is None or (isinstance(value, str) and bool(EFFORT_TOKEN_RE.fullmatch(value)))
 

--- a/scripts/install-all-runtimes.sh
+++ b/scripts/install-all-runtimes.sh
@@ -553,7 +553,7 @@ stamp_plugin_cache_releases() {
   fi
 }
 
-# Codex 플러그인은 MCP 번들을 지원하지 않으므로 config.toml에 직접 등록한다.
+# The Codex plugin doesn't support MCP bundles, so register directly in config.toml.
 # Workforce must have one canonical MCP entrypoint. Remove the old direct
 # `agentlas` table (which bypassed Core) and replace the owned local table while
 # preserving every unrelated user table. The obsolete remote-MCP feature flag
@@ -644,7 +644,7 @@ install_gemini() {
 
 antigravity_present() {
   [[ -d "$HOME/.gemini/antigravity" ]] && return 0
-  # "Antigravity IDE" 변형은 별도 데이터 디렉토리(~/.gemini/antigravity-ide)를 쓴다.
+  # The "Antigravity IDE" variant uses a separate data directory (~/.gemini/antigravity-ide).
   [[ -d "$HOME/.gemini/antigravity-ide" ]] && return 0
   # Current Antigravity installs leave this CLI state directory even before a
   # global_workflows directory exists. Treat it as a presence marker, but keep
@@ -664,11 +664,11 @@ install_antigravity() {
   log "== Antigravity workflow & plugins =="
   ensure_downloaded_source || return 1
 
-  # 두 데이터 디렉토리 변형 모두에 설치한다 — 어느 앱을 쓰든 같은 명령 집합이 보이게.
+  # Install into both data directory variants — so the same command set shows up whichever app you use.
   local installed=0
   local data_dir
   for data_dir in "$HOME/.gemini/antigravity" "$HOME/.gemini/antigravity-ide"; do
-    # 존재하는 데이터 디렉토리에만 설치하되, 둘 다 없으면 기본 경로를 생성한다.
+    # Install only into a data directory that exists, but create the default path if neither exists.
     if [[ -d "$data_dir" || ( "$installed" -eq 0 && "$data_dir" == "$HOME/.gemini/antigravity" ) ]]; then
       local global_dir="$data_dir/global_workflows"
       mkdir -p "$global_dir"
@@ -710,7 +710,7 @@ EOF
   ok=$((ok + 1))
 }
 
-# Antigravity는 ~/.gemini/config/mcp_config.json에서 MCP 서버를 읽는다 (serverUrl 키).
+# Antigravity reads MCP servers from ~/.gemini/config/mcp_config.json (the serverUrl key).
 register_antigravity_mcp() {
   local cfg_dir="$HOME/.gemini/config"
   local cfg="$cfg_dir/mcp_config.json"

--- a/scripts/verify-memory-contract.sh
+++ b/scripts/verify-memory-contract.sh
@@ -1,22 +1,23 @@
 #!/bin/bash
 # ══════════════════════════════════════════════════════════════════════════════
-# 메모리 계약 3표면 싱크 게이트 (Runtime Doctor 싱크와 동형).
+# Memory contract three-surface sync gate (isomorphic to the Runtime Doctor sync).
 #
-# 메모리 로직은 세 곳에 산다:
-#   1) 데스크탑  : agentlas_desktop/electron/agents/evolution-hep.ts + memory/context.ts
-#                  + store/run-events.ts (풀 아키텍처, TS)
-#   2) 터미널    : agentlas_terminal/engine/agentlas-memory-import.cjs 등 (공유 스토어)
-#   3) hep 플러그인: agentlas_cloud/{memory_contract,evolution_proposals,context_markers,
-#                  memory_import,memory_hook}.py (별도·경량, per-slug)
+# Memory logic lives in three places:
+#   1) Desktop:   agentlas_desktop/electron/agents/evolution-hep.ts + memory/context.ts
+#                 + store/run-events.ts (full architecture, TS)
+#   2) Terminal:  agentlas_terminal/engine/agentlas-memory-import.cjs and others (shared store)
+#   3) hep plugin: agentlas_cloud/{memory_contract,evolution_proposals,context_markers,
+#                 memory_import,memory_hook}.py (separate, lightweight, per-slug)
 #
-# 계약(셋이 같아야 하는 것):
-#   - .agentlas/evolution-proposals.json 모양 = agentlas.evolution-proposals.v1
-#   - context_source 마커 이름 = {pm_soul, code_map, sitemap, experience, memory}
-#   - 멤버 세포 키 규칙 = slug 를 그대로 cell id 로 (키보존)
+# Contract (what must match across all three):
+#   - .agentlas/evolution-proposals.json shape = agentlas.evolution-proposals.v1
+#   - context_source marker names = {pm_soul, code_map, sitemap, experience, memory}
+#   - member cell key rule = the slug itself as the cell id (key preserved)
 #
-# 방식: hep(Python)의 계약 상수/모양을 parity 테스트로 검증하고, 데스크탑 체크아웃이
-#   로컬에 있으면 TS 계약 문자열을 교차대조한다(공개 체크아웃/CI 에선 자동 스킵).
-#   메모리 계약을 바꾸면 세 곳 중 하나라도 어긋날 때 exit 1.
+# Method: verifies hep's (Python) contract constants/shapes via a parity test,
+#   and cross-checks TS contract strings if a Desktop checkout is present
+#   locally (auto-skipped on a public checkout/CI). exit 1 if the memory
+#   contract changes and any of the three surfaces disagrees.
 # ══════════════════════════════════════════════════════════════════════════════
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary
- Adds a **Source Code & Commit Language** rule to AGENTS.md: new commits and explanatory comments go in English going forward. Past git history is untouched. Localized product copy, i18n test fixtures, and illustrative Korean example strings stay as-is (rule spells out the exemption explicitly).
- Translates ~40 genuine explanatory Korean comments/docstrings across `agentlas_cloud/`, one internal-descriptor field in `interview/lenses.py`, and a few script headers.
- Deliberately **left untouched**: Korean keyword/synonym lists used for intent and domain classification (functional), security-detection regex patterns that specifically match Korean-language prompt injection/exfiltration attempts (translating would break detection), localized `*_KO` message strings paired with `*_EN` equivalents, and illustrative Korean example phrases embedded in already-English comments.
- Synced via `scripts/sync-adapters.sh` (`--check` reports no drift) into the `claude/` and `codex/` plugin mirrors.

## Test plan
- [x] `python3 -m py_compile` / `node --check` / `bash -n` clean on every edited file
- [x] `scripts/sync-adapters.sh --check` — no drift
- [x] Full test suite: **1026 passed, 14 subtests passed**

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>